### PR TITLE
[F2F-1121] - Fix Vulnerability in Name Separation

### DIFF
--- a/src/tests/unit/utils/PersonIdentityUtils.test.ts
+++ b/src/tests/unit/utils/PersonIdentityUtils.test.ts
@@ -241,47 +241,6 @@ describe("PersonIdentityUtils", () => {
 		expect(logger.error).toHaveBeenCalledWith({ "message": "Missing all or some of mandatory postalAddress fields (subBuildingName, buildingName, buildingNumber and streetName), unable to create the session" }, { "messageCode": "MISSING_ALL_MANDATORY_POSTAL_ADDRESS_FIELDS" });
 	});
 
-	describe("removeCaseInsensitive", () => {
-		it("should remove case-insensitive stringToSearch from original string", () => {
-			const inputString = "Hello World";
-			const stringToSearch = "world";
-			const expected = "Hello ";
-
-			const result = personIdentityUtils.removeCaseInsensitive(inputString, stringToSearch);
-
-			expect(result).toBe(expected);
-		});
-
-		it("should not modify the original string if stringToSearch is not found", () => {
-			const inputString = "Hello World";
-			const stringToSearch = "universe";
-
-			const result = personIdentityUtils.removeCaseInsensitive(inputString, stringToSearch);
-
-			expect(result).toBe(inputString);
-		});
-
-		it("should handle empty input string", () => {
-			const inputString = "";
-			const stringToSearch = "test";
-			const expected = "";
-
-			const result = personIdentityUtils.removeCaseInsensitive(inputString, stringToSearch);
-
-			expect(result).toBe(expected);
-		});
-
-		it("should handle empty stringToSearch", () => {
-			const inputString = "Hello World";
-			const stringToSearch = "";
-			const expected = "Hello World";
-
-			const result = personIdentityUtils.removeCaseInsensitive(inputString, stringToSearch);
-
-			expect(result).toBe(expected);
-		});
-	});
-
 	describe("GetNamesFromYoti", () => {	
 		it("return VcNameParts if F2F Name data matches Yoti Name data", () => {
 			const VcNameParts = personIdentityUtils.getNamesFromYoti("FRED JOHN", "SMITH");
@@ -326,5 +285,44 @@ describe("PersonIdentityUtils", () => {
 				}
 			},
 		);
+		
+		it.only("should return VcNameParts for Boaty McBoatface Boat Test", () => {
+			const testData = { ...documentFields, full_name: "Boaty McBoatface Boat" };
+			const expectedVcNameParts = {
+				nameParts: [
+					{ value: "Boaty", type: "GivenName" },
+					{ value: "McBoatface", type: "GivenName" },
+					{ value: "Boat", type: "FamilyName" },
+				],
+			};
+
+			const VcNameParts = personIdentityUtils.getNamesFromPersonIdentity(
+				{
+					...personDetails,
+					name: [
+						{
+							nameParts: [
+								{
+									type: "GivenName",
+									value: "boaty",
+								},
+								{
+									type: "GivenName",
+									value: "mcboatface",
+								},
+								{
+									type: "FamilyName",
+									value: "boat",
+								},
+							],
+						},
+					],
+				},
+				testData,
+				logger,
+			);
+
+			expect(VcNameParts[0].nameParts).toEqual(expectedVcNameParts.nameParts);
+		});
 	});
 });

--- a/src/tests/unit/utils/PersonIdentityUtils.test.ts
+++ b/src/tests/unit/utils/PersonIdentityUtils.test.ts
@@ -241,6 +241,47 @@ describe("PersonIdentityUtils", () => {
 		expect(logger.error).toHaveBeenCalledWith({ "message": "Missing all or some of mandatory postalAddress fields (subBuildingName, buildingName, buildingNumber and streetName), unable to create the session" }, { "messageCode": "MISSING_ALL_MANDATORY_POSTAL_ADDRESS_FIELDS" });
 	});
 
+	describe("removeCaseInsensitive", () => {
+		it("should remove case-insensitive stringToSearch from original string", () => {
+			const inputString = "Hello World";
+			const stringToSearch = "world";
+			const expected = "Hello ";
+
+			const result = personIdentityUtils.removeCaseInsensitive(inputString, stringToSearch);
+
+			expect(result).toBe(expected);
+		});
+
+		it("should not modify the original string if stringToSearch is not found", () => {
+			const inputString = "Hello World";
+			const stringToSearch = "universe";
+
+			const result = personIdentityUtils.removeCaseInsensitive(inputString, stringToSearch);
+
+			expect(result).toBe(inputString);
+		});
+
+		it("should handle empty input string", () => {
+			const inputString = "";
+			const stringToSearch = "test";
+			const expected = "";
+
+			const result = personIdentityUtils.removeCaseInsensitive(inputString, stringToSearch);
+
+			expect(result).toBe(expected);
+		});
+
+		it("should handle empty stringToSearch", () => {
+			const inputString = "Hello World";
+			const stringToSearch = "";
+			const expected = "Hello World";
+
+			const result = personIdentityUtils.removeCaseInsensitive(inputString, stringToSearch);
+
+			expect(result).toBe(expected);
+		});
+	});
+
 	describe("GetNamesFromYoti", () => {	
 		it("return VcNameParts if F2F Name data matches Yoti Name data", () => {
 			const VcNameParts = personIdentityUtils.getNamesFromYoti("FRED JOHN", "SMITH");

--- a/src/tests/unit/utils/PersonIdentityUtils.test.ts
+++ b/src/tests/unit/utils/PersonIdentityUtils.test.ts
@@ -286,7 +286,7 @@ describe("PersonIdentityUtils", () => {
 			},
 		);
 		
-		it.only("should return VcNameParts for Boaty McBoatface Boat Test", () => {
+		it("should return VcNameParts for Boaty McBoatface Boat Test", () => {
 			const testData = { ...documentFields, full_name: "Boaty McBoatface Boat" };
 			const expectedVcNameParts = {
 				nameParts: [

--- a/src/utils/PersonIdentityUtils.ts
+++ b/src/utils/PersonIdentityUtils.ts
@@ -9,6 +9,17 @@ import { ValidationHelper } from "./ValidationHelper";
 
 export const personIdentityUtils = {
 
+	removeCaseInsensitive(originalString: string, stringToSearch: string) {
+		const lowerPattern = stringToSearch.toLowerCase();
+		const lowerString = originalString.toLowerCase();
+
+		const patternIndex = lowerString.indexOf(lowerPattern);
+		if (patternIndex === -1) return originalString;
+
+		const removedString = originalString.slice(0, patternIndex) + originalString.slice(patternIndex + stringToSearch.length);
+		return removedString;
+	},
+
 	getNamesFromYoti(givenName: string, familyName: string): Name[] {
 		const givenNames = givenName.split(/\s+/);
 		const nameParts = givenNames.map((name) => ({ value: name, type: "GivenName" }));
@@ -31,11 +42,11 @@ export const personIdentityUtils = {
 		}
 
 		// Remove family name from the full name and split at spaces
-		const yotiGivenNameParts = yotiFullName.replace(new RegExp(f2fFamilyName, "i"), "").match(/\S+/g);
+		const yotiGivenNameParts = (this.removeCaseInsensitive(yotiFullName, f2fFamilyName).trim()).split(" ").filter(part => part !== "");
 		// Map the array of given names into the correct format
 		const nameParts = yotiGivenNameParts.map((name: string) => ({ value: name.trim(), type: "GivenName" }));
 		// Remove the given names from the full name, remove surrounding spaces, and map to correct format
-		nameParts.push({ value: yotiFullName.replace(new RegExp(f2fGivenNames, "i"), "").trim(), type: "FamilyName" });
+		nameParts.push({ value: this.removeCaseInsensitive(yotiFullName, f2fGivenNames).trim(), type: "FamilyName" });
 
 		return [{ nameParts }];
 	},


### PR DESCRIPTION
### What changed

Removed the useage of RegExp when replacing parts of the string for creating names as this could lead to forms of injection attacks if Regex chars are present in the individuals name

### Why did it change

Fix a Theoretical Vulnerability in Name Separation

### Issue tracking
https://govukverify.atlassian.net/browse/F2F-1121