### PR TITLE
[F2F-948] - F2F | BE | Create Mock for the Post Office Lookup

### DIFF
--- a/infra-l2-outbound-proxy/src/tests/infra/infra.test.ts
+++ b/infra-l2-outbound-proxy/src/tests/infra/infra.test.ts
@@ -10,8 +10,8 @@ it("Should contain only one Api Gateway V2 resource definition", () => {
 describe("Outbound Proxy Api Gateway Integration URLs", () => {
   test.each`
     ENVIRONMENT      | POSTOFFICEURL                                                                  | YOTIURL                               | PRETTYPROXYURL
-    ${"dev"}         | ${"https://f2f-post-office-stub-postofficestub.review-o.dev.account.gov.uk"}   | ${"https://api.yoti.com/idverify/v1"} | ${"proxy.review-o.dev.account.gov.uk"}
-    ${"build"}       | ${"https://f2f-post-office-stub-postofficestub.review-o.build.account.gov.uk"} | ${"https://api.yoti.com/idverify/v1"} | ${"proxy.review-o.build.account.gov.uk"}
+    ${"dev"}         | ${"https://locations.pol-platform.co.uk"}   | ${"https://api.yoti.com/idverify/v1"} | ${"proxy.review-o.dev.account.gov.uk"}
+    ${"build"}       | ${"https://locations.pol-platform.co.uk"} | ${"https://api.yoti.com/idverify/v1"} | ${"proxy.review-o.build.account.gov.uk"}
     ${"staging"}     | ${"https://locations.pol-platform.co.uk"}                                      | ${"https://api.yoti.com/idverify/v1"} | ${"proxy.review-o.staging.account.gov.uk"}
     ${"integration"} | ${"https://locations.pol-platform.co.uk"}                                      | ${"https://api.yoti.com/idverify/v1"} | ${"proxy.review-o.integration.account.gov.uk"}
     ${"production"}  | ${"https://locations.pol-platform.co.uk"}                                      | ${"https://api.yoti.com/idverify/v1"} | ${"proxy.review-o.account.gov.uk"}

--- a/infra-l2-outbound-proxy/template.yaml
+++ b/infra-l2-outbound-proxy/template.yaml
@@ -15,11 +15,11 @@ Conditions:
 Mappings:
   EnvironmentVariables:
     dev:
-      POSTOFFICEURL: "https://f2f-post-office-stub-postofficestub.review-o.dev.account.gov.uk"
+      POSTOFFICEURL: "https://locations.pol-platform.co.uk"
       YOTIURL: "https://api.yoti.com/idverify/v1"
       PRETTYPROXYURL: "proxy.review-o.dev.account.gov.uk"
     build:
-      POSTOFFICEURL: "https://f2f-post-office-stub-postofficestub.review-o.build.account.gov.uk"
+      POSTOFFICEURL: "https://locations.pol-platform.co.uk"
       YOTIURL: "https://api.yoti.com/idverify/v1"
       PRETTYPROXYURL: "proxy.review-o.build.account.gov.uk"
     staging:

--- a/src/tests/api/poStubAPI.test.ts
+++ b/src/tests/api/poStubAPI.test.ts
@@ -1,7 +1,7 @@
 import poStubPayloadData from "../data/poStubPayload.json";
 import { postPOCodeRequest } from "../utils/ApiTestSteps";
 
-describe("PO Endpoint /postoffice/locations/search", () => {
+describe.skip("PO Endpoint /postoffice/locations/search", () => {
 
 	const postPOParams = [
 		[400],

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -516,7 +516,7 @@ export function validateCriVcIssuedTxMAEvent(txmaEvent: any, yotiMockId: any): a
 } 
 
 export async function postPOCodeRequest(mockDelimitator: any, userData: any): Promise<any> {
-	const path = "/postoffice/locations/search";
+	const path = "/v1/locations/search";
 	try {
 		userData.searchString = userData.searchString + " " + mockDelimitator;
 		console.log("userData in try statement: ", userData);


### PR DESCRIPTION
### What changed
Restored L2-outbound-proxy to use PO location API and added skip flag for PO mock API tests, until deployment pipelines for the PO stub are in place

### Issue tracking
[KIWI-948](https://govukverify.atlassian.net/browse/KIWI-948)



[KIWI-948]: https://govukverify.atlassian.net/browse/KIWI-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ