### PR TITLE
[KIWI-1352] - Update configure-aws-credentials to v2

### DIFF
--- a/.github/workflows/post-merge-dynamo-to-build.yml
+++ b/.github/workflows/post-merge-dynamo-to-build.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_F2F_DDB_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-dynamo-to-dev.yml
+++ b/.github/workflows/post-merge-dynamo-to-dev.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_F2F_DDB_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-gov-notify-stub-to-build.yml
+++ b/.github/workflows/post-merge-gov-notify-stub-to-build.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_GOV_NOTIFY_STUB_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-gov-notify-stub-to-dev.yml
+++ b/.github/workflows/post-merge-gov-notify-stub-to-dev.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_GOV_NOTIFY_STUB_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-kms-build.yml
+++ b/.github/workflows/post-merge-kms-build.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_F2F_KMS_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-kms-dev.yml
+++ b/.github/workflows/post-merge-kms-dev.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_F2F_KMS_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-outbound-proxy-to-build.yml
+++ b/.github/workflows/post-merge-outbound-proxy-to-build.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_F2F_PROXY_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-outbound-proxy-to-dev.yml
+++ b/.github/workflows/post-merge-outbound-proxy-to-dev.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_F2F_PROXY_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-package-to-build.yml
+++ b/.github/workflows/post-merge-package-to-build.yml
@@ -39,7 +39,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_CRI_F2F_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-package-to-dev.yml
+++ b/.github/workflows/post-merge-package-to-dev.yml
@@ -39,7 +39,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_CRI_F2F_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-push-test-container-to-build.yml
+++ b/.github/workflows/post-merge-push-test-container-to-build.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_CRI_F2F_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-push-test-container-to-dev.yml
+++ b/.github/workflows/post-merge-push-test-container-to-dev.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_CRI_F2F_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-yoti-stub-to-build.yml
+++ b/.github/workflows/post-merge-yoti-stub-to-build.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.BUILD_YOTI_STUB_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/post-merge-yoti-stub-to-dev.yml
+++ b/.github/workflows/post-merge-yoti-stub-to-dev.yml
@@ -32,7 +32,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_YOTI_STUB_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pull-request-Dynamo.yml
+++ b/.github/workflows/pull-request-Dynamo.yml
@@ -81,7 +81,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.GH_F2F_DDB_VALIDATE_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pull-request-KMS.yml
+++ b/.github/workflows/pull-request-KMS.yml
@@ -81,7 +81,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.GH_F2F_KMS_VALIDATE_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pull-request-gov-notify-stub.yml
+++ b/.github/workflows/pull-request-gov-notify-stub.yml
@@ -83,7 +83,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.GH_GOV_NOTIFY_STUB_VALIDATE_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pull-request-outbound-proxy.yml
+++ b/.github/workflows/pull-request-outbound-proxy.yml
@@ -82,7 +82,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.GH_F2F_PROXY_VALIDATE_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pull-request-yoti-stub.yml
+++ b/.github/workflows/pull-request-yoti-stub.yml
@@ -83,7 +83,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.GH_IPV_STUB_VALIDATE_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -108,7 +108,7 @@ jobs:
           use-installer: true
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.CRI_F2F_GH_VALIDATE_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# di-ipv-cri-f2f-api
+# di-ipv-cri-f2f-api 
 
 # Gov Notify Templates
 The gov-notify-templates directory contains the templates required for sending email notification to the user. The name of the file matches the name of the template in the Gov notify portal for Face to Face Production service. The content of the file has the subject line and the message which should be copied without any changes as it includes gov notify formatting markdown.

--- a/f2f-ipv-stub/README.md
+++ b/f2f-ipv-stub/README.md
@@ -1,4 +1,4 @@
-# IPV Stub
+# IPV Stub 
 If there are requirements for data contract changes between IPV Core and CRIs, then please do not use the default stack to build and deploy and instead use a different stack with
 similar naming convention - i.e 
 ``` bash

--- a/gov-notify-stub/src/README.md
+++ b/gov-notify-stub/src/README.md
@@ -1,1 +1,1 @@
-# Gov Notify stub
+# Gov Notify stub 

--- a/infra-l2-outbound-proxy/README.md
+++ b/infra-l2-outbound-proxy/README.md
@@ -1,4 +1,4 @@
-# infra-l2-outbound-proxy
+# infra-l2-outbound-proxy 
 
 F2F Outbound Proxy API Gateway definition
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,4 @@
-# Face-To-Face Service
+# Face-To-Face Service 
 
 Face-To-Face Service
 

--- a/test-harness/README.md
+++ b/test-harness/README.md
@@ -1,4 +1,4 @@
-# Test Harness
+# Test Harness 
 
 This is a test harness that listens to events from IPV Core and TxMA SQS queues and puts them in the `${AWS::StackName}-f2f-event-test-${Environment}` bucket which can then be accessed using and API.
 

--- a/yoti-stub/src/README.md
+++ b/yoti-stub/src/README.md
@@ -1,1 +1,1 @@
-# Yoti stub
+# Yoti stub 


### PR DESCRIPTION
### What changed
Update all our Github workflows to use the latest aws-actions/configure-aws-credentials@v2 when Assuming AWS Role