### PR TITLE
[KIWI-1267] re-renables sigv4 in F2F

### DIFF
--- a/test-harness/test-harness-spec.yaml
+++ b/test-harness/test-harness-spec.yaml
@@ -14,14 +14,23 @@ tags:
   - name: Testing - API to enable automation
     description: Endpoint implemented to enable testing
 
-# x-amazon-apigateway-policy:
-#   Version: "2012-10-17"
-#   Statement:
-#     - Effect: "Allow"
-#       Principal:
-#         AWS: "${AWS::AccountId}"
-#       Action: "execute-api:Invoke"
-#       Resource: "execute-api:/*"
+x-amazon-apigateway-policy:
+  Version: "2012-10-17"
+  Statement:
+  - Effect: "Deny"
+    Principal:
+      AWS:  "*"
+    Action: "execute-api:Invoke"
+    Resource: "execute-api:/*"
+    Condition:
+      StringNotEquals:
+        "aws:PrincipalAccount":
+          - "${AWS::AccountId}"
+  - Effect: "Allow"
+    Principal:
+      AWS:  "*"
+    Action: "execute-api:Invoke"
+    Resource: "execute-api:/*"
 
 paths:
   getRecordBySessionId/{tableName}/{sessionId}:
@@ -58,6 +67,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "requestParamsOnly"
       x-amazon-apigateway-integration:
         httpMethod: POST
@@ -118,6 +129,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "requestParamsOnly"
       x-amazon-apigateway-integration:
         httpMethod: POST
@@ -172,6 +185,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "requestParamsOnly"
       x-amazon-apigateway-integration:
         httpMethod: POST
@@ -221,6 +236,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "requestParamsOnly"
       x-amazon-apigateway-integration:
         httpMethod: GET
@@ -276,6 +293,8 @@ paths:
           description: Unauthorized
         "500":
           description: Internal Server Error
+      security:
+        - sigv4Reference: []
       x-amazon-apigateway-request-validator: "requestParamsOnly"
       x-amazon-apigateway-integration:
         httpMethod: GET
@@ -294,10 +313,21 @@ paths:
             statusCode: "200"
         type: aws
 
-# components:
-#   securitySchemes:
-#     SigV4Reference:
-#       type: apiKey
-#       name: Authorization
-#       in: header
-#       x-amazon-apigateway-authtype: awsSigv4
+components:
+  securitySchemes:
+    sigv4Reference:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: awsSigv4
+
+x-amazon-apigateway-request-validators:
+    both:
+      validateRequestBody: true
+      validateRequestParameters: true
+    requestBodyOnly:
+      validateRequestBody: true
+      validateRequestParameters: false
+    requestParamsOnly:
+      validateRequestBody: false
+      validateRequestParameters: true


### PR DESCRIPTION
## Proposed changes

### What changed

Re-renables sigv4 in F2F

### Why did it change

To secure our test harness endpoints

### Screenshots

<img width="1299" alt="image" src="https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/40401118/3791612e-1725-4124-81f2-f26edee3aa96">

<img width="591" alt="Screenshot 2023-10-26 at 11 46 33 am" src="https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/40401118/318409dc-99df-4e1b-a688-6c43fc931be1">

### Issue tracking

- [KIWI-1267](https://govukverify.atlassian.net/browse/KIWI-1267)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[KIWI-1267]: https://govukverify.atlassian.net/browse/KIWI-1267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ