### PR TITLE
[KIWI-1374] Add new obfuscateJSONValues method and log out obfuscated TxMA Events

### DIFF
--- a/src/services/F2fService.ts
+++ b/src/services/F2fService.ts
@@ -152,6 +152,29 @@ export class F2fService {
 		}
 	}
 
+	async obfuscateJSONValues(input: any, txmaFieldsToShow: string[] = []): Promise<any> {
+		if (typeof input === "object" && input !== null) {
+			if (Array.isArray(input)) {
+				return Promise.all(input.map((element) => this.obfuscateJSONValues(element, txmaFieldsToShow)));
+			} else {
+				const obfuscatedObject: any = {};
+				for (const key in input) {
+					if (input.hasOwnProperty(key)) {
+						if (txmaFieldsToShow.includes(key)) {
+							obfuscatedObject[key] = input[key];
+						} else {
+							obfuscatedObject[key] = await this.obfuscateJSONValues(input[key], txmaFieldsToShow);
+						}
+					}
+				}
+				return obfuscatedObject;
+			}
+		} else {
+			return "***";
+		}
+	}
+	
+
 	async sendToTXMA(event: TxmaEvent): Promise<void> {
 		try {
 			const messageBody = JSON.stringify(event);
@@ -164,6 +187,10 @@ export class F2fService {
 
 			await sqsClient.send(new SendMessageCommand(params));
 			this.logger.info("Sent message to TxMA");
+
+			this.obfuscateJSONValues(event, Constants.TXMA_FIELDS_TO_SHOW).then((obfuscatedObject) => {
+				this.logger.info({ message: "Obfuscated TxMA Event", txmaEvent: JSON.stringify(obfuscatedObject, null, 2) });
+			});
 		} catch (error) {
 			this.logger.error({ message: "Error when sending message to TXMA Queue", error });
 			throw new AppError(HttpCodesEnum.SERVER_ERROR, "sending event to txma queue - failed ");

--- a/src/tests/unit/SessionConfigHandler.test.ts
+++ b/src/tests/unit/SessionConfigHandler.test.ts
@@ -10,7 +10,7 @@ import { VALID_SESSION_CONFIG } from "./data/session-config-events";
 const mockSessionConfigRequestProcessor = mock<SessionConfigRequestProcessor>();
 
 describe("SessionConfigHandler", () => {
-	let event = {
+	const event = {
 		requestContext: { requestId: "sampleRequestId" },
 		headers: {},
 	} as APIGatewayProxyEvent;

--- a/src/tests/unit/services/F2fService.test.ts
+++ b/src/tests/unit/services/F2fService.test.ts
@@ -10,6 +10,7 @@ import { GovNotifyEvent } from "../../../utils/GovNotifyEvent";
 import { absoluteTimeNow } from "../../../utils/DateTimeUtils";
 import { personIdentityInputRecord, personIdentityOutputRecord } from "../data/personIdentity-records";
 import { AppError } from "../../../utils/AppError";
+import { Constants } from "../../../utils/Constants";
 
 const logger = mock<Logger>();
 
@@ -444,4 +445,82 @@ describe("F2f Service", () => {
 			message: "updateItem - failed: got error updating SESSIONTABLE",
 		}));
 	});	
+
+	describe("obfuscateJSONValues", () => {
+		it("should obfuscate all fields except those in txmaFieldsToShow", async () => {
+			const inputObject = {
+				field1: "sensitive1",
+				field2: "sensitive2",
+				field3: "non-sensitive",
+				nested: {
+					field4: "sensitive3",
+					field5: "non-sensitive",
+				},
+			};
+	
+			const txmaFieldsToShow = ["field3", "field5"];
+	
+			const obfuscatedObject = await f2fService.obfuscateJSONValues(inputObject, txmaFieldsToShow);
+	
+			// Check that sensitive fields are obfuscated and non-sensitive fields are not
+			expect(obfuscatedObject.field1).toBe("***");
+			expect(obfuscatedObject.field2).toBe("***");
+			expect(obfuscatedObject.field3).toBe("non-sensitive");
+			expect(obfuscatedObject.nested.field4).toBe("***");
+			expect(obfuscatedObject.nested.field5).toBe("non-sensitive");
+		});
+	
+		it("should handle arrays correctly", async () => {
+			const inputObject = {
+				field1: "sensitive1",
+				arrayField: [
+					{
+						field2: "sensitive2",
+						field3: "non-sensitive",
+					},
+					{
+						field2: "sensitive3",
+						field3: "non-sensitive",
+					},
+				],
+			};
+	
+			const txmaFieldsToShow = ["field3"];
+	
+			const obfuscatedObject = await f2fService.obfuscateJSONValues(inputObject, txmaFieldsToShow);
+	
+			// Check that sensitive fields are obfuscated and non-sensitive fields are not
+			expect(obfuscatedObject.field1).toBe("***");
+			expect(obfuscatedObject.arrayField[0].field2).toBe("***");
+			expect(obfuscatedObject.arrayField[0].field3).toBe("non-sensitive");
+			expect(obfuscatedObject.arrayField[1].field2).toBe("***");
+			expect(obfuscatedObject.arrayField[1].field3).toBe("non-sensitive");
+		});
+	
+		it("should obfuscate values of different types", async () => {
+			const inputObject = {
+				stringField: "sensitive-string",
+				numberField: 42,
+				booleanField: true,
+			};
+	
+			const txmaFieldsToShow: string[] | undefined = [];
+	
+			const obfuscatedObject = await f2fService.obfuscateJSONValues(inputObject, txmaFieldsToShow);
+	
+			// Check that all fields are obfuscated
+			expect(obfuscatedObject.stringField).toBe("***");
+			expect(obfuscatedObject.numberField).toBe("***");
+			expect(obfuscatedObject.booleanField).toBe("***");
+		});
+	
+		it('should return "***" for non-object input', async () => {
+			const input = "string-input";
+	
+			const obfuscatedValue = await f2fService.obfuscateJSONValues(input);
+	
+			// Check that non-object input is obfuscated as '***'
+			expect(obfuscatedValue).toBe("***");
+		});
+	});
 });

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -91,7 +91,8 @@ export class Constants {
 		LAST_NAME: "last name",
 		LINK_TO_FILE: "link_to_file",
 		CHOSEN_PHOTO_ID: "chosen photo ID",
-
 	};
+
+	static readonly TXMA_FIELDS_TO_SHOW = ["event_name", "documentType"];
   
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Adds new method to obfuscate TxMA Events before logging them out in Splunk everytime we send a TxMA Event


**Test Event**
``{
	"client_id":"ipv-core-stub",
	"component_id":"https://XXX-c.env.account.gov.uk",
	"event_name":"F2F_YOTI_RESPONSE_RECEIVED",
	"timestamp":1684933200,
	"extensions":{
		 "evidence":[
				{
					 "txn":"b83d54ce-1565-42ee-987a-97a1f48f27dg"
				}
		 ],
		 "post_office_details":[
				{
					 "address":"1 The Street, Funkytown",
					 "location":[
							{
								 "latitude":0.34322,
								 "longitude":-42.48372
							}
					 ],
					 "post_code":"SW19 4NS"
				}
		 ]
	},
	"user":{
		 "govuk_signin_journey_id":"sdfssg",
		 "ip_address":"127.0.0.1",
		 "persistent_session_id":"sdgsdg",
		 "session_id":"RandomF2FSessionID",
		 "user_id":"sub"
	},
	"restricted":{
		 "passport":[
				{
					 "documentType":"PASSPORT"
				}
		 ]
	}
}``

**obfuscated value**
<img width="306" alt="image" src="https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/13416125/120672ff-9a3f-40ad-b080-7f13c9905608">


