### PR TITLE
KIWI-1544: Remove GovNotifyThrottleAlarm attached to SQS

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -5140,21 +5140,6 @@ Resources:
                 {
                   "height": 6,
                   "width": 12,
-                  "y": 12,
-                  "x": 12,
-                  "type": "metric",
-                  "properties": {
-                    "title": "GovNotify Throttles - ${AWS::StackName}",
-                    "annotations": {
-                      "alarms": ["${GovNotifyThrottleAlarm.Arn}"]
-                    },
-                    "view": "timeSeries",
-                    "stacked": false
-                  }
-                },
-                {
-                  "height": 6,
-                  "width": 12,
                   "y": 18,
                   "x": 0,
                   "type": "metric",


### PR DESCRIPTION
### What changed

Removed the GovNotifyThrottleAlarm

### Why did it change

Removed the GovNotifyThrottleAlarm

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1544](https://govukverify.atlassian.net/browse/KIWI-1544)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1544]: https://govukverify.atlassian.net/browse/KIWI-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ