### PR TITLE
IPS-528: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/src'
+    schedule:
+      interval: daily
+      time: "03:00"
+    target-branch: main
+    labels:
+    - dependabot
+    ignore:
+      - dependency-name: "node"
+        versions: ["17.x","18.x"]
+    commit-message:
+      prefix: BAU
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    target-branch: main
+    labels:
+    - dependabot


### PR DESCRIPTION
### What changed

Add dependabot file(sonarcloud was already excluded in https://github.com/govuk-one-login/ipv-cri-f2f-api/pull/298)

Dependabot secrets will need to be added separately according to https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3473244443/Dependabot+and+GitHub+secrets

### Why did it change

Dependabot is an automated tool that helps manage dependencies and keep them up to date. This is recommended by the [identity team manual](https://team-manual.account.gov.uk/development-standards-processes/dependabot/). Configuration of the tool in BAV API workflows was missed during the initial repository setup so is added as part of this ticket.

### Issue tracking
- [IPS-528] (https://govukverify.atlassian.net/browse/IPS-528)
- [KIWI-1533](https://govukverify.atlassian.net/browse/KIWI-1533)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-528]: https://govukverify.atlassian.net/browse/IPS-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KIWI-1533]: https://govukverify.atlassian.net/browse/KIWI-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ