### PR TITLE
[KIWI-1580] - F2F | BE | Include nameParts in F2F_YOTI_START

### DIFF
--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -224,6 +224,7 @@ export class DocumentSelectionRequestProcessor {
 						  ],
   				},
   				restricted: {
+					name: personDetails.name,
   					[docName]: [
   						{
   							documentType: docType,

--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -224,7 +224,7 @@ export class DocumentSelectionRequestProcessor {
 						  ],
   				},
   				restricted: {
-					name: personDetails.name,
+  					name: personDetails.name,
   					[docName]: [
   						{
   							documentType: docType,

--- a/src/tests/unit/data/txmaEvent.ts
+++ b/src/tests/unit/data/txmaEvent.ts
@@ -212,10 +212,18 @@ const TXMA_YOTI_START_EXTENSION = {
 	},
 };
 
+
 export const TXMA_PASSPORT_YOTI_START = {
 	...TXMA_CORE_FIELDS,
 	...TXMA_YOTI_START_EXTENSION,
 	restricted: {
+		"name": [{
+			"nameParts": [
+				{ "value": "Frederick", "type": "GivenName" },
+				{ "value": "Joseph", "type": "GivenName" },
+				{ "value": "Flintstone", "type": "FamilyName" },
+			],
+		}],
 		"passport": [
 			{
 				"documentType": "PASSPORT",
@@ -237,6 +245,13 @@ export const TXMA_NATIONAL_ID_YOTI_START = {
 	...TXMA_CORE_FIELDS,
 	...TXMA_YOTI_START_EXTENSION,
 	restricted: {
+		"name": [{
+			"nameParts": [
+				{ "value": "Frederick", "type": "GivenName" },
+				{ "value": "Joseph", "type": "GivenName" },
+				{ "value": "Flintstone", "type": "FamilyName" },
+			],
+		}],
 		"idCard": [
 			{
 				"documentType": "NATIONAL_ID",


### PR DESCRIPTION
### What changed

Update `F2F_YOTI_START` TxMA event in `/documentSelection` lambda with nameParts 

### Issue tracking
- [KIWI-1580](https://govukverify.atlassian.net/browse/KIWI-1580)

![image](https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/118540036/44622b12-10b0-4b39-a6b5-d3bf1f0dbf2c)


[KIWI-1580]: https://govukverify.atlassian.net/browse/KIWI-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ