### PR TITLE
KIWI-1556: Fix failing tests

### DIFF
--- a/src/tests/api/UserInfoNegativePath.test.ts
+++ b/src/tests/api/UserInfoNegativePath.test.ts
@@ -19,7 +19,7 @@ describe("Negative Path /userInfo Endpoint", () => {
 		// // Post Token
 		const tokenResponse = await tokenPost(authResponse.data.authorizationCode.value, authResponse.data.redirect_uri );
 		// Post User Info
-		const userInfoResponse = await userInfoPost("Bearer ");
+		const userInfoResponse = await userInfoPost("Bearer 123");
 		expect(userInfoResponse.status).toBe(400);
 		expect(userInfoResponse.data).toBe("Failed to Validate - Authentication header: Failed to verify signature");
 	});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated test data to match new validation rules

### Why did it change

Bearer token validation was changed in [this PR](https://github.com/govuk-one-login/ipv-cri-f2f-api/pull/343/files#diff-bde75dd86488a04faf567e64bdaf207dd95ba4983dfacd3e7f395cc1241559c6) and the API test was not updated

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1556](https://govukverify.atlassian.net/browse/KIWI-1556)
