### PR TITLE
[KIWI-1546] - Allow additional properties in /docSelect payload

### DIFF
--- a/deploy/f2f-spec.yaml
+++ b/deploy/f2f-spec.yaml
@@ -1034,7 +1034,7 @@ components:
               description: claimed expiry date for the document to be presented at the post office
         post_office_selection:
           type: object
-          additionalProperties: false
+          additionalProperties: true
           required:
             - address
             - post_code


### PR DESCRIPTION
### What changed

Changed OpenAPI spec for /documentSelection endpoint, to allow additional attributes in the payload

### Why did it change

To allow merging of [KIWI-1475](https://govukverify.atlassian.net/browse/KIWI-1475) without causing breaking changes

### Issue tracking
FE: [KIWI-1475](https://govukverify.atlassian.net/browse/KIWI-1475)
BE: [KIWI-1546](https://govukverify.atlassian.net/browse/KIWI-1546)


[KIWI-1475]: https://govukverify.atlassian.net/browse/KIWI-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIWI-1475]: https://govukverify.atlassian.net/browse/KIWI-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIWI-1546]: https://govukverify.atlassian.net/browse/KIWI-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ