### PR TITLE
[KIWI-1413] - Add missing import to ApiTestSteps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "di-ipv-cri-f2f-api",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/src/tests/api/Yoti.test.ts
+++ b/src/tests/api/Yoti.test.ts
@@ -40,7 +40,7 @@ describe("Yoti /sessions endpoint", () => {
 		[503, "3503"],
 		  ];
 	it.each(putInstructionsParams)("Yoti - expect '%i' response on PUT/ssessions/{id}/instructions '/sessions/%s/instructions'", async (responseCode, sessionId) => {
-		const fadcodePayload = { "branch": { "fad_code":"1234567" } }
+		const fadcodePayload = { "branch": { "fad_code":"1234567" } };
 		const response = await putYotiSessionsInstructions(sessionId as string, fadcodePayload);
 		expect(response.status).toBe(responseCode);
 	});

--- a/src/tests/api/Yoti.test.ts
+++ b/src/tests/api/Yoti.test.ts
@@ -2,6 +2,8 @@
 import yotiRequestData from "../data/yotiSessionsPayloadValid.json";
 import { postYotiSession, getYotiSessionsConfiguration, putYotiSessionsInstructions, getYotiSessionsInstructions } from "../utils/ApiTestSteps";
 
+const payload = {"branch": {"fad_code":"1234567"}}
+
 describe("Yoti /sessions endpoint", () => {
 	//responseCode, user_tracking_ui
 	const postSessionsParams = [
@@ -40,7 +42,7 @@ describe("Yoti /sessions endpoint", () => {
 		[503, "3503"],
 		  ];
 	it.each(putInstructionsParams)("Yoti - expect '%i' response on PUT/ssessions/{id}/instructions/pdf '/sessions/%s/instructions/pdf'", async (responseCode, sessionId) => {
-		const response = await putYotiSessionsInstructions(sessionId);
+		const response = await putYotiSessionsInstructions(sessionId, payload);
 		expect(response.status).toBe(responseCode);
 	});
 

--- a/src/tests/api/Yoti.test.ts
+++ b/src/tests/api/Yoti.test.ts
@@ -2,7 +2,7 @@
 import yotiRequestData from "../data/yotiSessionsPayloadValid.json";
 import { postYotiSession, getYotiSessionsConfiguration, putYotiSessionsInstructions, getYotiSessionsInstructions } from "../utils/ApiTestSteps";
 
-const payload = {"branch": {"fad_code":"1234567"}}
+const payload = { "branch": { "fad_code":"1234567" } };
 
 describe("Yoti /sessions endpoint", () => {
 	//responseCode, user_tracking_ui

--- a/src/tests/api/Yoti.test.ts
+++ b/src/tests/api/Yoti.test.ts
@@ -2,8 +2,6 @@
 import yotiRequestData from "../data/yotiSessionsPayloadValid.json";
 import { postYotiSession, getYotiSessionsConfiguration, putYotiSessionsInstructions, getYotiSessionsInstructions } from "../utils/ApiTestSteps";
 
-const payload = { "branch": { "fad_code":"1234567" } };
-
 describe("Yoti /sessions endpoint", () => {
 	//responseCode, user_tracking_ui
 	const postSessionsParams = [
@@ -14,7 +12,7 @@ describe("Yoti /sessions endpoint", () => {
 		[503, "1503"],
 	];
 	it.each(postSessionsParams)("Yoti - expect '%i' response on POST/sessions '/sessions'", async (responseCode, userTrackerId) => {
-		const response = await postYotiSession(userTrackerId, yotiRequestData);
+		const response = await postYotiSession(userTrackerId as string, yotiRequestData);
 		expect(response.status).toBe(responseCode);
 	});
 
@@ -28,7 +26,7 @@ describe("Yoti /sessions endpoint", () => {
 		[503, "2503"],
 	  ];
 	it.each(getConfigurationParams)("Yoti - expect '%i' response on GET/sessions/configuration '/sessions/%s/configuration'", async (responseCode, sessionId) => {
-		const response = await getYotiSessionsConfiguration(sessionId);
+		const response = await getYotiSessionsConfiguration(sessionId as string);
 		expect(response.status).toBe(responseCode);
 	});
 
@@ -41,8 +39,9 @@ describe("Yoti /sessions endpoint", () => {
 		[409, "3409"],
 		[503, "3503"],
 		  ];
-	it.each(putInstructionsParams)("Yoti - expect '%i' response on PUT/ssessions/{id}/instructions/pdf '/sessions/%s/instructions/pdf'", async (responseCode, sessionId) => {
-		const response = await putYotiSessionsInstructions(sessionId, payload);
+	it.each(putInstructionsParams)("Yoti - expect '%i' response on PUT/ssessions/{id}/instructions '/sessions/%s/instructions'", async (responseCode, sessionId) => {
+		const fadcodePayload = { "branch": { "fad_code":"1234567" } }
+		const response = await putYotiSessionsInstructions(sessionId as string, fadcodePayload);
 		expect(response.status).toBe(responseCode);
 	});
 
@@ -56,8 +55,8 @@ describe("Yoti /sessions endpoint", () => {
 		[500, "4500"],
 		[503, "4503"],
 	];
-	it.each(getInstructionsParams)("Yoti - expect '%i' response on GET/sessions/instructions '/sessions/%s/instructions'", async (responseCode, sessionId) => {
-		const response = await getYotiSessionsInstructions(sessionId);
+	it.each(getInstructionsParams)("Yoti - expect '%i' response on GET/sessions/instructions/pdf '/sessions/%s/instructions/pdf'", async (responseCode, sessionId) => {
+		const response = await getYotiSessionsInstructions(sessionId as string);
 		expect(response.status).toBe(responseCode);
 	});
 });

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -172,11 +172,11 @@ export async function getYotiSessionsConfiguration(sessionId: any): Promise<any>
 	}
 }
 
-export async function putYotiSessionsInstructions(sessionId: any): Promise<any> {
+export async function putYotiSessionsInstructions(sessionId: any, payload: any): Promise<any> {
 	const path = constants.DEV_F2F_YOTI_STUB_URL + "/sessions/" + sessionId + "/instructions";
 	console.log(path);
 	try {
-		const postRequest = await YOTI_INSTANCE.put(path);
+		const postRequest = await YOTI_INSTANCE.put(path, payload);
 		return postRequest;
 
 	} catch (error: any) {

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -145,7 +145,7 @@ export async function sessionConfigurationGet(sessionId: any):Promise<any> {
 		return error.response;
 	}
 }
-export async function postYotiSession(trackingId: any, userData: any): Promise<any> {
+export async function postYotiSession(trackingId: string, userData: any): Promise<any> {
 	const path = "/sessions";
 	try {
 		// update fullName to contain trackingId - this determines the behaviour of the Yoti mock
@@ -159,7 +159,7 @@ export async function postYotiSession(trackingId: any, userData: any): Promise<a
 	}
 }
 
-export async function getYotiSessionsConfiguration(sessionId: any): Promise<any> {
+export async function getYotiSessionsConfiguration(sessionId: string): Promise<any> {
 	const path = constants.DEV_F2F_YOTI_STUB_URL + "/sessions/" + sessionId + "/configuration";
 	console.log(path);
 	try {
@@ -172,11 +172,11 @@ export async function getYotiSessionsConfiguration(sessionId: any): Promise<any>
 	}
 }
 
-export async function putYotiSessionsInstructions(sessionId: any, payload: any): Promise<any> {
+export async function putYotiSessionsInstructions(sessionId: string, fadcodePayload: { branch: { fad_code: string } }): Promise<any> {
 	const path = constants.DEV_F2F_YOTI_STUB_URL + "/sessions/" + sessionId + "/instructions";
 	console.log(path);
 	try {
-		const postRequest = await YOTI_INSTANCE.put(path, payload);
+		const postRequest = await YOTI_INSTANCE.put(path, fadcodePayload);
 		return postRequest;
 
 	} catch (error: any) {
@@ -186,7 +186,7 @@ export async function putYotiSessionsInstructions(sessionId: any, payload: any):
 }
 
 
-export async function getYotiSessionsInstructions(sessionId: any): Promise<any> {
+export async function getYotiSessionsInstructions(sessionId: string): Promise<any> {
 	const path = constants.DEV_F2F_YOTI_STUB_URL + "/sessions/" + sessionId + "/instructions/pdf";
 	console.log(path);
 	try {

--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -6,6 +6,7 @@ import { XMLParser } from "fast-xml-parser";
 import { ISessionItem } from "../../models/ISessionItem";
 import { constants } from "../utils/ApiConstants";
 import { jwtUtils } from "../../utils/JwtUtils";
+import crypto from "node:crypto";
 
 const GOV_NOTIFY_INSTANCE = axios.create({ baseURL: constants.GOV_NOTIFY_API });
 const API_INSTANCE = axios.create({ baseURL: constants.DEV_CRI_F2F_API_URL });


### PR DESCRIPTION
### What changed

Fix for [KIWI-1413](https://govukverify.atlassian.net/browse/KIWI-1413)
Added new line to include missing import, this is causing api tests to fail in the pipeline

[KIWI-1413]: https://govukverify.atlassian.net/browse/KIWI-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ