### PR TITLE
[KIWI-1413] - Add missing import to ApiTestSteps

### DIFF
--- a/src/tests/utils/ApiTestSteps.ts
+++ b/src/tests/utils/ApiTestSteps.ts
@@ -6,6 +6,7 @@ import { XMLParser } from "fast-xml-parser";
 import { ISessionItem } from "../../models/ISessionItem";
 import { constants } from "../utils/ApiConstants";
 import { jwtUtils } from "../../utils/JwtUtils";
+import crypto from "node:crypto";
 
 const GOV_NOTIFY_INSTANCE = axios.create({ baseURL: constants.GOV_NOTIFY_API });
 const API_INSTANCE = axios.create({ baseURL: constants.DEV_CRI_F2F_API_URL });


### PR DESCRIPTION
### What changed

Fix for [KIWI-1413](https://govukverify.atlassian.net/browse/KIWI-1413)
Added new line to include missing import, this is causing api tests to fail in the pipeline

[KIWI-1413]: https://govukverify.atlassian.net/browse/KIWI-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ