### PR TITLE
[KIWI-1701] Make formatted_address optional

### DIFF
--- a/src/services/YotiSessionCompletionProcessor.ts
+++ b/src/services/YotiSessionCompletionProcessor.ts
@@ -356,7 +356,7 @@ export class YotiSessionCompletionProcessor {
 			  } else {
 				  documentInfo.issuedBy = documentFields.issuing_authority;
 				  documentInfo.issueDate = documentFields.date_of_issue;
-				  documentInfo.fullAddress = documentFields.structured_postal_address ? documentFields.structured_postal_address.formatted_address : undefined;
+				  documentInfo.fullAddress = documentFields.structured_postal_address?.formatted_address;
 			  }
 			  break;
 		  case DocumentTypes.NATIONAL_ID:

--- a/src/services/YotiSessionCompletionProcessor.ts
+++ b/src/services/YotiSessionCompletionProcessor.ts
@@ -356,7 +356,7 @@ export class YotiSessionCompletionProcessor {
 			  } else {
 				  documentInfo.issuedBy = documentFields.issuing_authority;
 				  documentInfo.issueDate = documentFields.date_of_issue;
-				  documentInfo.fullAddress = documentFields.structured_postal_address.formatted_address;
+				  documentInfo.fullAddress = documentFields.structured_postal_address ? documentFields.structured_postal_address.formatted_address : undefined;
 			  }
 			  break;
 		  case DocumentTypes.NATIONAL_ID:

--- a/src/tests/api/CallbackApi.test.ts
+++ b/src/tests/api/CallbackApi.test.ts
@@ -27,6 +27,7 @@ describe("/callback endpoint", () => {
 	it.each([
 		{ yotiMockId: "0000", docSelectionData: dataUkDrivingLicence },
 		{ yotiMockId: "0001", docSelectionData: dataUkDrivingLicence },
+		{ yotiMockId: "0003", docSelectionData: dataUkDrivingLicence },
 		{ yotiMockId: "0101", docSelectionData: dataPassport },
 		{ yotiMockId: "0102", docSelectionData: dataPassport },
 		{ yotiMockId: "0103", docSelectionData: dataPassport },

--- a/src/tests/api/HappyPath.test.ts
+++ b/src/tests/api/HappyPath.test.ts
@@ -82,7 +82,7 @@ describe("/documentSelection Endpoint", () => {
 
 		expect(Number(updatedYotiSessionExpiry)).toBeGreaterThan(Number(initinalYotiSessionExpiry));
 	});
-
+	
 	it.each([
 		{ buildingNumber: "32", buildingName: "", subBuildingName: "" },
 		{ buildingNumber: "", buildingName: "19 A", subBuildingName: "" },

--- a/src/tests/data/vcValidationData.json
+++ b/src/tests/data/vcValidationData.json
@@ -13,6 +13,13 @@
         "checkMethod": "vri,pvr",
         "ci": null
     },
+    "s0003":{
+        "strengthScore": 3,
+        "validityScore": 2,
+        "verificationScore": 3,
+        "checkMethod": "vri,bvr",
+        "ci": null
+    },
     "s0100":{
         "strengthScore": 4,
         "validityScore": 3,

--- a/src/tests/unit/data/txmaEvent.ts
+++ b/src/tests/unit/data/txmaEvent.ts
@@ -105,6 +105,34 @@ export const TXMA_DL_VC_ISSUED = {
 	},
 };
 
+export const TXMA_DL_VC_ISSUED_WITHOUT_FULL_ADDRESS = {
+	...TXMA_CORE_FIELDS,
+	...TXMA_EXTENSION,
+	restricted: {
+		"name": [{
+			"nameParts": [
+				{ "value": "LEEROY", "type": "GivenName" },
+				{ "value": "JENKINS", "type": "FamilyName" },
+			],
+		}],
+		"birthDate": [
+			{
+				"value": "1988-12-04",
+			},
+		],
+		"drivingPermit": [
+			{
+				"documentType": "DRIVING_LICENCE",
+				"personalNumber": "LJENK533401372",
+				"expiryDate": "2025-09-28",
+				"issuingCountry": "GBR",
+				"issuedBy": "DVLA",
+				"issueDate": "2015-09-28",
+			},
+		],
+	},
+};
+
 export const TXMA_EU_DL_VC_ISSUED = {
 	...TXMA_CORE_FIELDS,
 	...TXMA_EXTENSION,

--- a/src/tests/unit/services/YotiSessionCompletionProcessor.test.ts
+++ b/src/tests/unit/services/YotiSessionCompletionProcessor.test.ts
@@ -19,8 +19,8 @@ import { VerifiableCredentialService } from "../../../services/VerifiableCredent
 import { AppError } from "../../../utils/AppError";
 import { MessageCodes } from "../../../models/enums/MessageCodes";
 import { PersonIdentityItem } from "../../../models/PersonIdentityItem";
-import { TXMA_BRP_VC_ISSUED, TXMA_CORE_FIELDS, TXMA_DL_VC_ISSUED, TXMA_EEA_VC_ISSUED, TXMA_EU_DL_VC_ISSUED, TXMA_VC_ISSUED } from "../data/txmaEvent";
-import { getBrpFields, getCompletedYotiSession, getDocumentFields, getDrivingPermitFields, getEeaIdCardFields, getEuDrivingPermitFields } from "../utils/YotiCallbackUtils";
+import { TXMA_BRP_VC_ISSUED, TXMA_CORE_FIELDS, TXMA_DL_VC_ISSUED, TXMA_DL_VC_ISSUED_WITHOUT_FULL_ADDRESS, TXMA_EEA_VC_ISSUED, TXMA_EU_DL_VC_ISSUED, TXMA_VC_ISSUED } from "../data/txmaEvent";
+import { getBrpFields, getCompletedYotiSession, getDocumentFields, getDrivingPermitFields, getDrivingPermitFieldsWithoutPostalAddress, getEeaIdCardFields, getEuDrivingPermitFields } from "../utils/YotiCallbackUtils";
 
 let mockCompletedSessionProcessor: YotiSessionCompletionProcessor;
 const mockF2fService = mock<F2fService>();
@@ -295,6 +295,204 @@ describe("YotiSessionCompletionProcessor", () => {
 								"postalCode":"EH1 9GP",
 								"addressCountry":"United Kingdom",
 							},
+						],
+						"drivingPermit":[
+								 {
+								"personalNumber": "LJENK533401372",
+								"expiryDate": "2025-09-28",
+								"issueDate": "2015-09-28",
+								"issuedBy": "DVLA",
+
+								 },
+						],
+					 },
+					 "evidence":[
+						{
+								 "type":"IdentityCheck",
+							      "txn":"b988e9c8-47c6-430c-9ca3-8cdacd85ee91",
+								 "strengthScore":3,
+								 "validityScore":2,
+								 "verificationScore":3,
+								 "checkDetails":[
+								{
+											 "checkMethod":"vri",
+											 "identityCheckPolicy":"published",
+								},
+								{
+											 "checkMethod":"pvr",
+											 "photoVerificationProcessLevel":3,
+								},
+								 ],
+						},
+					 ],
+				},
+		 })],
+		});
+		expect(out.statusCode).toBe(HttpCodesEnum.OK);
+		expect(out.body).toBe("OK");
+	});
+
+	it("Return successful response with 200 OK when YOTI session is completed for driving permit- Media not containing formatted_address", async () => {
+		documentFields = getDrivingPermitFieldsWithoutPostalAddress();
+		const ukDLYotiSession =  getCompletedYotiSession();
+		ukDLYotiSession.resources.id_documents[0].document_type = "DRIVING_LICENCE";
+		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(ukDLYotiSession);
+		mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
+		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+		// @ts-ignore
+		mockCompletedSessionProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
+
+		const out: Response = await mockCompletedSessionProcessor.processRequest(VALID_REQUEST);
+
+		expect(mockF2fService.sendToTXMA).toHaveBeenCalledTimes(2);
+		const ukDlcoreFields = TXMA_CORE_FIELDS;
+		ukDlcoreFields.timestamp = 1585695600;
+		ukDlcoreFields.event_timestamp_ms = 1585695600000;
+		expect(mockF2fService.sendToTXMA).toHaveBeenNthCalledWith(1, ukDlcoreFields);
+		const ukDlVcIssued =  TXMA_DL_VC_ISSUED_WITHOUT_FULL_ADDRESS;
+		ukDlVcIssued.event_name = "F2F_CRI_VC_ISSUED";
+		ukDlVcIssued.timestamp = 1585695600;
+		ukDlVcIssued.event_timestamp_ms = 1585695600000;
+		expect(mockF2fService.sendToTXMA).toHaveBeenNthCalledWith(2, ukDlVcIssued);
+		expect(mockF2fService.sendToIPVCore).toHaveBeenCalledTimes(1);
+		expect(mockF2fService.sendToIPVCore).toHaveBeenCalledWith({
+			sub: "testsub",
+			state: "Y@atr",
+			"https://vocab.account.gov.uk/v1/credentialJWT": [JSON.stringify({
+				"sub":"testsub",
+				"nbf":absoluteTimeNow(),
+				"iss":"https://XXX-c.env.account.gov.uk",
+				"iat":absoluteTimeNow(),
+				"jti":Constants.URN_UUID_PREFIX + "sdfsdf",
+				"vc":{
+					"@context":[
+					 Constants.W3_BASE_CONTEXT,
+					 Constants.DI_CONTEXT,
+					],
+					"type": [Constants.VERIFIABLE_CREDENTIAL, Constants.IDENTITY_CHECK_CREDENTIAL],
+					 "credentialSubject":{
+						"name":[
+								 {
+								"nameParts":[
+											 {
+										"value":"LEEROY",
+										"type":"GivenName",
+											 },
+											 {
+										"value":"JENKINS",
+										"type":"FamilyName",
+											 },
+								],
+								 },
+						],
+						"birthDate":[
+								 {
+								"value":"1988-12-04",
+								 },
+						],
+						"address":[
+							{
+								"buildingNumber":"122",
+								"streetName":"BURNS CRESCENT",
+								"addressLocality":"STORMWIND",
+								"postalCode":"EH1 9GP",
+								"addressCountry":"United Kingdom",
+							},
+						],
+						"drivingPermit":[
+								 {
+								"personalNumber": "LJENK533401372",
+								"expiryDate": "2025-09-28",
+								"issueDate": "2015-09-28",
+								"issuedBy": "DVLA",
+
+								 },
+						],
+					 },
+					 "evidence":[
+						{
+								 "type":"IdentityCheck",
+							      "txn":"b988e9c8-47c6-430c-9ca3-8cdacd85ee91",
+								 "strengthScore":3,
+								 "validityScore":2,
+								 "verificationScore":3,
+								 "checkDetails":[
+								{
+											 "checkMethod":"vri",
+											 "identityCheckPolicy":"published",
+								},
+								{
+											 "checkMethod":"pvr",
+											 "photoVerificationProcessLevel":3,
+								},
+								 ],
+						},
+					 ],
+				},
+		 })],
+		});
+		expect(out.statusCode).toBe(HttpCodesEnum.OK);
+		expect(out.body).toBe("OK");
+	});
+
+	it("Return successful response with 200 OK when YOTI session is completed for driving permit- Media not containing structured_postal_address", async () => {
+		documentFields = getDrivingPermitFieldsWithoutPostalAddress();
+		delete documentFields.structured_postal_address;
+		const ukDLYotiSession =  getCompletedYotiSession();
+		ukDLYotiSession.resources.id_documents[0].document_type = "DRIVING_LICENCE";
+		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(ukDLYotiSession);
+		mockYotiService.getMediaContent.mockResolvedValueOnce(documentFields);
+		mockF2fService.getSessionByYotiId.mockResolvedValueOnce(f2fSessionItem);
+		// @ts-ignore
+		mockCompletedSessionProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
+
+		const out: Response = await mockCompletedSessionProcessor.processRequest(VALID_REQUEST);
+
+		expect(mockF2fService.sendToTXMA).toHaveBeenCalledTimes(2);
+		const ukDlcoreFields = TXMA_CORE_FIELDS;
+		ukDlcoreFields.timestamp = 1585695600;
+		ukDlcoreFields.event_timestamp_ms = 1585695600000;
+		expect(mockF2fService.sendToTXMA).toHaveBeenNthCalledWith(1, ukDlcoreFields);
+		const ukDlVcIssued =  TXMA_DL_VC_ISSUED_WITHOUT_FULL_ADDRESS;
+		ukDlVcIssued.event_name = "F2F_CRI_VC_ISSUED";
+		ukDlVcIssued.timestamp = 1585695600;
+		ukDlVcIssued.event_timestamp_ms = 1585695600000;
+		expect(mockF2fService.sendToTXMA).toHaveBeenNthCalledWith(2, ukDlVcIssued);
+		expect(mockF2fService.sendToIPVCore).toHaveBeenCalledTimes(1);
+		expect(mockF2fService.sendToIPVCore).toHaveBeenCalledWith({
+			sub: "testsub",
+			state: "Y@atr",
+			"https://vocab.account.gov.uk/v1/credentialJWT": [JSON.stringify({
+				"sub":"testsub",
+				"nbf":absoluteTimeNow(),
+				"iss":"https://XXX-c.env.account.gov.uk",
+				"iat":absoluteTimeNow(),
+				"jti":Constants.URN_UUID_PREFIX + "sdfsdf",
+				"vc":{
+					"@context":[
+					 Constants.W3_BASE_CONTEXT,
+					 Constants.DI_CONTEXT,
+					],
+					"type": [Constants.VERIFIABLE_CREDENTIAL, Constants.IDENTITY_CHECK_CREDENTIAL],
+					 "credentialSubject":{
+						"name":[
+								 {
+								"nameParts":[
+											 {
+										"value":"LEEROY",
+										"type":"GivenName",
+											 },
+											 {
+										"value":"JENKINS",
+										"type":"FamilyName",
+											 },
+								],
+								 },
+						],
+						"birthDate":[
+								 {
+								"value":"1988-12-04",
+								 },
 						],
 						"drivingPermit":[
 								 {

--- a/src/tests/unit/services/YotiSessionCompletionProcessor.test.ts
+++ b/src/tests/unit/services/YotiSessionCompletionProcessor.test.ts
@@ -20,7 +20,7 @@ import { AppError } from "../../../utils/AppError";
 import { MessageCodes } from "../../../models/enums/MessageCodes";
 import { PersonIdentityItem } from "../../../models/PersonIdentityItem";
 import { TXMA_BRP_VC_ISSUED, TXMA_CORE_FIELDS, TXMA_DL_VC_ISSUED, TXMA_DL_VC_ISSUED_WITHOUT_FULL_ADDRESS, TXMA_EEA_VC_ISSUED, TXMA_EU_DL_VC_ISSUED, TXMA_VC_ISSUED } from "../data/txmaEvent";
-import { getBrpFields, getCompletedYotiSession, getDocumentFields, getDrivingPermitFields, getDrivingPermitFieldsWithoutPostalAddress, getEeaIdCardFields, getEuDrivingPermitFields } from "../utils/YotiCallbackUtils";
+import { getBrpFields, getCompletedYotiSession, getDocumentFields, getDrivingPermitFields, getDrivingPermitFieldsWithoutFormattedAddress, getEeaIdCardFields, getEuDrivingPermitFields } from "../utils/YotiCallbackUtils";
 
 let mockCompletedSessionProcessor: YotiSessionCompletionProcessor;
 const mockF2fService = mock<F2fService>();
@@ -333,7 +333,7 @@ describe("YotiSessionCompletionProcessor", () => {
 	});
 
 	it("Return successful response with 200 OK when YOTI session is completed for driving permit- Media not containing formatted_address", async () => {
-		documentFields = getDrivingPermitFieldsWithoutPostalAddress();
+		documentFields = getDrivingPermitFieldsWithoutFormattedAddress();
 		const ukDLYotiSession =  getCompletedYotiSession();
 		ukDLYotiSession.resources.id_documents[0].document_type = "DRIVING_LICENCE";
 		mockYotiService.getCompletedSessionInfo.mockResolvedValueOnce(ukDLYotiSession);
@@ -436,7 +436,7 @@ describe("YotiSessionCompletionProcessor", () => {
 	});
 
 	it("Return successful response with 200 OK when YOTI session is completed for driving permit- Media not containing structured_postal_address", async () => {
-		documentFields = getDrivingPermitFieldsWithoutPostalAddress();
+		documentFields = getDrivingPermitFieldsWithoutFormattedAddress();
 		delete documentFields.structured_postal_address;
 		const ukDLYotiSession =  getCompletedYotiSession();
 		ukDLYotiSession.resources.id_documents[0].document_type = "DRIVING_LICENCE";

--- a/src/tests/unit/utils/YotiCallbackUtils.ts
+++ b/src/tests/unit/utils/YotiCallbackUtils.ts
@@ -376,7 +376,7 @@ export function getDrivingPermitFields(): any {
 	return documentFields;
 }
 
-export function getDrivingPermitFieldsWithoutPostalAddress(): any {
+export function getDrivingPermitFieldsWithoutFormattedAddress(): any {
 	const documentFields = {
 		"full_name": "LEEROY JENKINS",
 		"date_of_birth": "1988-12-04",

--- a/src/tests/unit/utils/YotiCallbackUtils.ts
+++ b/src/tests/unit/utils/YotiCallbackUtils.ts
@@ -376,6 +376,35 @@ export function getDrivingPermitFields(): any {
 	return documentFields;
 }
 
+export function getDrivingPermitFieldsWithoutPostalAddress(): any {
+	const documentFields = {
+		"full_name": "LEEROY JENKINS",
+		"date_of_birth": "1988-12-04",
+		"given_names": "LEEROY",
+		"family_name": "JENKINS",
+		"place_of_birth": "UNITED KINGDOM",
+		"gender": "MALE",
+		"structured_postal_address": {
+			"address_format": 1,
+			"building_number": "122",
+			"address_line1": "122 BURNS CRESCENT",
+			"address_line2": "EDINBURGH",
+			"address_line3": "EH1 9GP",
+			"town_city": "STORMWIND",
+			"postal_code": "EH1 9GP",
+			"country_iso": "GBR",
+			"country": "United Kingdom",
+		},
+		"document_type": "DRIVING_LICENCE",
+		"issuing_country": "GBR",
+		"document_number": "LJENK533401372",
+		"expiration_date": "2025-09-28",
+		"date_of_issue": "2015-09-28",
+		"issuing_authority": "DVLA",
+	};
+	return documentFields;
+}
+
 export function getEuDrivingPermitFields(): any {
 	const documentFields = {
 		"full_name": "Erika - Mustermann",

--- a/yoti-stub/src/data/getMediaContent/gbDriversLicenseMissingFormatedAddressResponse.ts
+++ b/yoti-stub/src/data/getMediaContent/gbDriversLicenseMissingFormatedAddressResponse.ts
@@ -1,0 +1,14 @@
+export const GBR_DRIVING_LICENCE_MISSING_FORMATTED_ADDRESS = {
+	"full_name": "SARAH MEREDYTH MORGAN",
+	"date_of_birth": "1976-03-11",
+	"given_names": "SARAH MEREDYTH",
+	"family_name": "MORGAN",
+	"place_of_birth": "UNITED KINGDOM",
+	"gender": "FEMALE",
+	"document_type": "DRIVING_LICENCE",
+	"issuing_country": "GBR",
+	"document_number": "MORGA753116SM9IJ35",
+	"expiration_date": "2023-01-18",
+	"date_of_issue": "2013-01-19",
+	"issuing_authority": "DVLA"
+}

--- a/yoti-stub/src/services/YotiRequestProcessor.ts
+++ b/yoti-stub/src/services/YotiRequestProcessor.ts
@@ -30,7 +30,8 @@ import {
     UK_PASSPORT_MEDIA_ID_ANTHONY,
     UK_PASSPORT_MEDIA_ID_PAUL,
     IPV_INTEG_FULL_NAME_SUZIE,
-    UK_PASSPORT_MEDIA_ID_SUZIE
+    UK_PASSPORT_MEDIA_ID_SUZIE,
+    UK_DL_MISSING_FORMATTED_ADDRESS_MEDIA_ID
 } from "../utils/Constants";
 import {HttpCodesEnum} from "../utils/HttpCodesEnum";
 import {YotiSessionItem} from "../models/YotiSessionItem";
@@ -104,6 +105,7 @@ import { DEU_DRIVING_LICENCE_INCORRECT_NAME_SEQUENCE } from "../data/getMediaCon
 import {GBR_PASSPORT_PAUL} from "../data/getMediaContent/gbPassportResponsePAUL";
 import {GBR_PASSPORT_ANTHONY} from "../data/getMediaContent/gbPassportResponseANTHONY";
 import {GBR_PASSPORT_SUZIE} from "../data/getMediaContent/gbPassportResponseSUZIE";
+import { GBR_DRIVING_LICENCE_MISSING_FORMATTED_ADDRESS } from "../data/getMediaContent/gbDriversLicenseMissingFormatedAddressResponse";
 
 export class YotiRequestProcessor {
     private static instance: YotiRequestProcessor;
@@ -308,6 +310,14 @@ export class YotiRequestProcessor {
                     VALID_DL_RESPONSE_0002.resources.id_documents[0].document_fields.media.id = sessionId;
                     VALID_DL_RESPONSE_0002.resources.id_documents[0].document_fields.media.id = replaceLastUuidChars(VALID_DL_RESPONSE_0002.resources.id_documents[0].document_fields.media.id, UK_DL_WRONG_NON_SPACE_CHARS);
                     return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_DL_RESPONSE_0002));
+
+                    case '0003': // UK Driving License Success - No formatted_address in structural_address
+                        logger.debug(JSON.stringify(yotiSessionRequest));
+                        const VALID_DL_RESPONSE_0003 = JSON.parse(JSON.stringify(VALID_DL_RESPONSE));
+                        VALID_DL_RESPONSE_0003.session_id = sessionId; 
+                        VALID_DL_RESPONSE_0003.resources.id_documents[0].document_fields.media.id = sessionId;
+                        VALID_DL_RESPONSE_0003.resources.id_documents[0].document_fields.media.id = replaceLastUuidChars(VALID_DL_RESPONSE_0003.resources.id_documents[0].document_fields.media.id, UK_DL_MISSING_FORMATTED_ADDRESS_MEDIA_ID);
+                        return new Response(HttpCodesEnum.OK, JSON.stringify(VALID_DL_RESPONSE_0003));
 
                     default:
                         return undefined;
@@ -1442,6 +1452,9 @@ export class YotiRequestProcessor {
 
             case EEA_ID_MEDIA_ID:
                 return new Response(HttpCodesEnum.OK, JSON.stringify(NLD_NATIONAL_ID));
+            
+            case UK_DL_MISSING_FORMATTED_ADDRESS_MEDIA_ID:
+                return new Response(HttpCodesEnum.OK, JSON.stringify(GBR_DRIVING_LICENCE_MISSING_FORMATTED_ADDRESS));
 
             case '5400':
                 logger.info({message: "last 4 ID chars", lastUuidChars});

--- a/yoti-stub/src/utils/Constants.ts
+++ b/yoti-stub/src/utils/Constants.ts
@@ -41,6 +41,8 @@ export const EU_DL_INCORRECT_NAME_SEQUENCE: string = '0402'
 
 export const EEA_ID_MEDIA_ID: string = "0500"
 
+export const UK_DL_MISSING_FORMATTED_ADDRESS_MEDIA_ID = "0003"
+
 export const SUPPORTED_DOCUMENTS: string[] = [DocumentMapping.UK_DL, DocumentMapping.UK_PASSPORT, DocumentMapping.NON_UK_PASSPORT,
                                               DocumentMapping.BRP, DocumentMapping.EU_DL, DocumentMapping.EEA_ID] // <-- Update this Array when introducing new doucment types
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Make formatted_address optional while generating TXMA event.
Yoti mock updated with new code- 0003 to test UK DL without structured_postal_address in the media response.
Unit-tests added to test these negative cases
https://govukverify.atlassian.net/wiki/spaces/FTFCRI/pages/3557818744/Yoti+Journey+4+Scenarios updated with new yoti mock code- 0003

### Why did it change

Fixes the error which occurs when this field is missing in the media response for a yoti-session

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1701](https://govukverify.atlassian.net/browse/KIWI-1701)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

Evidence of successful TXMA event generation which does not include the fullAddress incase formatted_address field is missing or structured_postal_address field is missing in the documentFields received from Yoti media endpoint.
<img width="551" alt="1701_txma_without_fullAddress" src="https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/115095929/b08ea3c2-afcc-4f1e-9b88-886f1b633ed9">


Api tests passing with theses changes as well, evidence attached below for ref;
<img width="503" alt="Screenshot 2024-03-27 at 21 58 06" src="https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/115095929/cbcaeece-24b5-4567-b558-09c604c80003">




[KIWI-1701]: https://govukverify.atlassian.net/browse/KIWI-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ