### PR TITLE
Re-enabled failed UnhappyPath /session Endpoint test

### DIFF
--- a/src/tests/api/UnhappyPath.test.ts
+++ b/src/tests/api/UnhappyPath.test.ts
@@ -33,16 +33,16 @@ describe("/session endpoint", () => {
 		expect(sessionResponse.data).toBe("Unauthorized");
 	});
 
-	// KIWI-1750: calls to /session returning 200 status code when Family Name is missing in shared_claims payload
-	// it("Unsuccessful Request Tests - No Family Name Field", async () => {
-	//     const newf2fStubPayload = structuredClone(f2fStubPayload);
-	// 	newf2fStubPayload.shared_claims.name[0].nameParts[2].value = "";
-	//     console.log(JSON.stringify(newf2fStubPayload));
-	// 	const stubResponse = await stubStartPost(newf2fStubPayload);
-	// 	const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
-	// 	expect(sessionResponse.status).toBe(401);
-	// 	expect(sessionResponse.data).toBe("Unauthorized");
-	// });
+	it("Unsuccessful Request Tests - No Family Name Field", async () => {
+	    const newf2fStubPayload = structuredClone(f2fStubPayload);
+		newf2fStubPayload.yotiMockID = "";
+		newf2fStubPayload.shared_claims.name[0].nameParts[2].value = "";
+	    console.log(JSON.stringify(newf2fStubPayload));
+		const stubResponse = await stubStartPost(newf2fStubPayload);
+		const sessionResponse = await sessionPost(stubResponse.data.clientId, stubResponse.data.request);
+		expect(sessionResponse.status).toBe(401);
+		expect(sessionResponse.data).toBe("Unauthorized");
+	});
 
 	it("Unsuccessful Request Tests - No Email Address", async () => {
 		const newf2fStubPayload = structuredClone(f2fStubPayload);


### PR DESCRIPTION
Unhappy Path Test Results: 
![image](https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/110032361/7b235190-5d0e-4ee0-a86e-4ace4701da17)


## Proposed changes

### What changed

Re-enable failed /session endpoint Happy Path test with updated logic

### Why did it change

After investigation - we need to remove yotiMockId from shared_claims for test to pass

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1750](https://govukverify.atlassian.net/browse/KIWI-1750)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1750]: https://govukverify.atlassian.net/browse/KIWI-1750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ