### PR TITLE
[KIWI-1726]- Handle incomplete data from post office API

### DIFF
--- a/post-office-stub/src/data/postOfficeResponse/postOfficeResponseNoName.ts
+++ b/post-office-stub/src/data/postOfficeResponse/postOfficeResponseNoName.ts
@@ -1,0 +1,13 @@
+export const POST_OFFICE_RESPONSE_NO_NAME =
+	{
+		"@timestamp": "2024-03-04T20:05:28.969Z",
+		"level": "FATAL",
+		"message": "Unhandled Exception: Cannot read properties of undefined (reading 'name')",
+		"host": "ip-10-0-7-127.eu-west-2.compute.internal",
+		"label": "di-ipv-cri-f2f-front:exception",
+		"stack": [
+			"TypeError: Cannot read properties of undefined (reading 'name')",
+			"    at /app/src/app/f2f/controllers/results.js:72:37",
+			"    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
+		]
+	};

--- a/post-office-stub/src/services/PostOfficeRequestProcessor.ts
+++ b/post-office-stub/src/services/PostOfficeRequestProcessor.ts
@@ -1,5 +1,6 @@
 import { Response } from "../utils/Response";
 import { POST_OFFICE_RESPONSE } from "../data/postOfficeResponse/postOfficeSuccessResponse";
+import { POST_OFFICE_RESPONSE_NO_NAME } from "../data/postOfficeResponse/postOfficeResponseNoName";
 import { HttpCodesEnum } from "../utils/HttpCodesEnum";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { Metrics } from "@aws-lambda-powertools/metrics";
@@ -53,6 +54,9 @@ export class PostOfficeRequestProcessor {
     		case "503":
     			this.logger.info({ message: "Returning 503 response back" });
     			return new Response(HttpCodesEnum.SERVICE_UNAVAILABLE, JSON.stringify(POST_REPONSE_503));
+    		case "NAME":
+    			this.logger.info({ message: "Returning missing name error object" });
+    			return new Response(HttpCodesEnum.OK, JSON.stringify(POST_OFFICE_RESPONSE_NO_NAME));
     		default:
     			this.logger.info({ message: "Successful request" });
     			return new Response(HttpCodesEnum.OK, JSON.stringify(POST_OFFICE_RESPONSE));

--- a/src/tests/api/StubTests.test.ts
+++ b/src/tests/api/StubTests.test.ts
@@ -89,6 +89,7 @@ describe("Post Office Stub", () => {
 		["500"],
 		["200"],
 		["503"],
+		["NAME"]
 	];
 
 	it.each(postPOParams)("Post Office Stub - expect '%i' response on POST/postoffice/locations/search", async (poStubDelimitator: string) => {


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the Post Office mock to return the error object detailed in the ticket, which in the real Post Office API is generated by the name field being returned as undefined

### Why did it change

In order to return a mock error so that it could be handled correctly in the front end 

### Issue tracking

- [KIWI-1726](https://govukverify.atlassian.net/browse/KIWI-1726)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
