### PR TITLE
KIWI-1863: Update Test Harness Spec - /getSessionByState endpoint

### DIFF
--- a/test-harness/test-harness-spec.yaml
+++ b/test-harness/test-harness-spec.yaml
@@ -214,6 +214,73 @@ paths:
           default:
             statusCode: "200"
         type: aws
+
+  getSessionByState/{tableName}/{state}:
+    get:
+      operationId: getSessionByState
+      summary: Get a session by using state-index from DynamoDB
+      description: |
+        Endpoint to get a session from DynamoDB using either state as the primary key
+      parameters:
+        - name: tableName
+          in: path
+          description: The name of the table to find the record in DynamoDB
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: path
+          description: The value of the secondary index identifier to find the record in DynamoDB
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  session:
+                    type: object
+                    description: The found session from DynamoDB.
+        "401":
+          description: Unauthorized
+        "500":
+          description: Internal Server Error
+      security:
+        - sigv4Reference: []
+      x-amazon-apigateway-request-validator: "requestParamsOnly"
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        credentials:
+          Fn::GetAtt: [ "DynamoDbAccessRole", "Arn" ]
+        uri: "arn:aws:apigateway:${AWS::Region}:dynamodb:action/Query"
+        passthroughBehavior: when_no_match
+        requestParameters:
+          integration.request.header.Content-Type: "'application/x-www-form-urlencoded'"
+          integration.request.path.tableName: "method.request.path.tableName"
+          integration.request.path.state: "method.request.path.state"
+        requestTemplates:
+          application/json: |
+            {
+              "TableName":"$input.params('tableName')",
+              "IndexName":"state-index",
+              "KeyConditionExpression": "#st = :state",
+              "ExpressionAttributeNames": {
+                  "#st": "state"
+              },
+              "ExpressionAttributeValues":{
+                  ":state":{
+                    "S":"$input.params('state')"
+                  }
+              }
+            }
+        responses:
+          default:
+            statusCode: "200"
+        type: aws
   
   /bucket/:
     get:


### PR DESCRIPTION
<img width="1167" alt="image" src="https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/110032361/fb648e80-c2f8-4728-ab9e-4dc5913afab6">

## Proposed changes

### What changed

Add new endpoint to Test Harness Spec
- getSessionByState

### Why did it change

Support E2E testing of abort logic - state value exposed in FE abort journey but not authorizationCode
New endpoint needed to get session data using state

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1863](https://govukverify.atlassian.net/browse/KIWI-1863)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1863]: https://govukverify.atlassian.net/browse/KIWI-1863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ