### PR TITLE
Remove IsNotProdLikeEnvironment condition from yoti-stub pipeline

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -100,7 +100,6 @@ Mappings:
 
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
-      YOTIBASEURL: "https://f2f-yoti-stub-yotistub.review-o.dev.account.gov.uk"
       YOTISDK: "1f9edc97-c60c-40d7-becb-c1c6a2ec4963"
       ISSUER: 'https://review-o.dev.account.gov.uk'
       DNSSUFFIX: review-o.dev.account.gov.uk
@@ -134,7 +133,6 @@ Mappings:
       IPVCOREACCOUNT: arn:aws:iam::130355686670:root
       TESTHARNESSURL: "https://f2f-test-harness-testharness.review-o.dev.account.gov.uk"
     build:
-      YOTIBASEURL: "https://yotistub.review-o.build.account.gov.uk"
       YOTISDK: "1f9edc97-c60c-40d7-becb-c1c6a2ec4963"
       ISSUER: 'https://review-o.build.account.gov.uk'
       DNSSUFFIX: review-o.build.account.gov.uk
@@ -5970,10 +5968,6 @@ Outputs:
     Description: "F2F IPV Stub"
     Value:
       Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubExecuteUrl'
-  F2FYotiStubURL:
-    Condition: IsNotProdLikeEnvironment
-    Description: "F2F Yoti Stub"
-    Value: !FindInMap [EnvironmentVariables, !Ref Environment, YOTIBASEURL]
   TxMASQSQueue:
     Description: "Arn of the TxMASQSQueue"
     Value: !GetAtt TxMASQSQueue.Arn

--- a/yoti-stub/template.yaml
+++ b/yoti-stub/template.yaml
@@ -301,6 +301,5 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-MockYotiApiGatewayId
   F2FYotiStubURL:
-    Condition: IsNotProdLikeEnvironment
     Description: "F2F Yoti Stub"
     Value: !FindInMap [EnvironmentVariables, !Ref Environment, YOTIBASEURLTWO]


### PR DESCRIPTION
### What changed

Fixes broken yoti-stub deployment

<img width="1507" alt="image" src="https://github.com/govuk-one-login/ipv-cri-f2f-api/assets/13416125/0ae80b35-ca84-40f9-97f5-658078819688">
