### PR TITLE
IPS-901: grant pipeline test role Lambda:invoke on ExpiredSession Function

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -62,6 +62,11 @@ Parameters:
     Description: "Set to true to apply reserved concurrency when deploying in DEV environments"
     Type: String
     Default: "false"
+  TestRoleArn:
+    Description: "ARN of the role used during pipeline test stage, allowing Lambda invocations. Injected by the deployment pipeline"
+    Type: String
+    Default: none
+
 
 Mappings:
   EnvironmentConfiguration: # This is where you store per-environment settings.
@@ -407,7 +412,7 @@ Resources:
   InternetGatewayEventMetricFilter:
     Type: 'AWS::Logs::MetricFilter'
     Condition: DeployAlarms
-    Properties: 
+    Properties:
       LogGroupName: !Ref SessionFunctionLogGroup
       FilterPattern: '{ ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }'
       MetricTransformations:
@@ -418,7 +423,7 @@ Resources:
   InternetGatewayActivityEventErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms
-    Properties: 
+    Properties:
       AlarmName: !Sub "${AWS::StackName}-IGW-changes"
       AlarmDescription: !Sub "Triggers CloudWatch Alarm when changes are made to an Internet Gateway in a VPC. ${SupportManualURL}"
       MetricName: IGatewayActivityEvent
@@ -522,7 +527,7 @@ Resources:
       OKActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
       TreatMissingData: notBreaching
-        
+
 
   LambdaEgressSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
@@ -2721,6 +2726,14 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !Ref ExpiredSessionsFunction
       Principal: apigateway.amazonaws.com
+
+  ExpiredSessionFunctionTestRolePermission:
+    Type: AWS::Lambda::Permission
+    Condition: IsNotProdLikeEnvironment
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt ExpiredSessionsFunction.Value
+      Principal: !Ref TestRoleArn
 
   ExpiredSessionsFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -6143,7 +6156,7 @@ Resources:
                 }
               ]
             }
-  
+
   CriticalAlarmDashboard:
     Type: AWS::CloudWatch::Dashboard
     Condition: DeployAlarms
@@ -6633,7 +6646,7 @@ Resources:
             ]
           }
 
- 
+
 
 Outputs:
   F2FApiGatewayId:

--- a/src/tests/infra/template.test.ts
+++ b/src/tests/infra/template.test.ts
@@ -1,4 +1,4 @@
-import { Template, Match } from 'aws-cdk-lib/assertions';
+import { Template, Match } from "aws-cdk-lib/assertions";
 const { schema } = require("yaml-cfn");
 import { readFileSync } from "fs";
 import { load } from "js-yaml";
@@ -8,167 +8,175 @@ import { load } from "js-yaml";
 let template: Template;
 
 describe("Infra", () => {
-	beforeAll(() => {
-		const yamltemplate: any = load(
-			readFileSync("../deploy/template.yaml", "utf-8"),
-			{ schema },
-		);
-		delete yamltemplate.Resources.F2FRestApi.Properties.DefinitionBody; // To be removed, not SAM compatible.
-		template = Template.fromJSON(yamltemplate);
-	});
+  beforeAll(() => {
+    const yamltemplate: any = load(
+      readFileSync("../deploy/template.yaml", "utf-8"),
+      { schema },
+    );
+    delete yamltemplate.Resources.F2FRestApi.Properties.DefinitionBody; // To be removed, not SAM compatible.
+    template = Template.fromJSON(yamltemplate);
+  });
 
-	it.skip("Should define a DefinitionBody as part of the serverless::api", () => {
-		// N.B this only passes as we currently delete it on line 14 in the test setup step.
-		template.hasResourceProperties("AWS::Serverless::Api", {
-			DefinitionBody: Match.anyValue(),
-		});
-	});
+  it.skip("Should define a DefinitionBody as part of the serverless::api", () => {
+    // N.B this only passes as we currently delete it on line 14 in the test setup step.
+    template.hasResourceProperties("AWS::Serverless::Api", {
+      DefinitionBody: Match.anyValue(),
+    });
+  });
 
-	it.skip("API specification in the spec folder should match the DefinitionBody", () => {
-		const api_definition: any = load(readFileSync("../deploy/spec/private-api.yaml", "utf-8"), { schema });
-		template.hasResourceProperties("AWS::Serverless::Api", {
-			DefinitionBody: Match.objectEquals(api_definition),
-		});
+  it.skip("API specification in the spec folder should match the DefinitionBody", () => {
+    const api_definition: any = load(
+      readFileSync("../deploy/spec/private-api.yaml", "utf-8"),
+      { schema },
+    );
+    template.hasResourceProperties("AWS::Serverless::Api", {
+      DefinitionBody: Match.objectEquals(api_definition),
+    });
+  });
 
-	});
+  it.skip("Should not define a Events section as part of the serverless::function", () => {
+    // N.B this only passes as we currently delete it on line 14 in the test setup step.
+    template.hasResourceProperties("AWS::Serverless::Function", {
+      Events: Match.absent(),
+    });
+  });
 
-	it.skip("Should not define a Events section as part of the serverless::function", () => {
-		// N.B this only passes as we currently delete it on line 14 in the test setup step.
-		template.hasResourceProperties("AWS::Serverless::Function", {
-			Events: Match.absent(),
-		});
-	});
+  it("The template contains one API gateway resource", () => {
+    template.resourceCountIs("AWS::Serverless::Api", 1);
+  });
 
-	it("The template contains one API gateway resource", () => {
-		template.resourceCountIs("AWS::Serverless::Api", 1);
-	});
+  it("Each API Gateway should have TracingEnabled", () => {
+    const apiGateways = template.findResources("AWS::Serverless::Api");
+    const apiGatewayList = Object.keys(apiGateways);
+    apiGatewayList.forEach((apiGatewayId) => {
+      expect(apiGateways[apiGatewayId].Properties.TracingEnabled).toEqual(true);
+    });
+  });
 
-	it("Each API Gateway should have TracingEnabled", () => {
-		const apiGateways = template.findResources("AWS::Serverless::Api");
-		const apiGatewayList = Object.keys(apiGateways);
-		apiGatewayList.forEach((apiGatewayId) => {
-			expect(apiGateways[apiGatewayId].Properties.TracingEnabled).toEqual(true);
-		});
-	});
+  it("Each API Gateway should have MethodSettings defined", () => {
+    const apiGateways = template.findResources("AWS::Serverless::Api");
+    const apiGatewayList = Object.keys(apiGateways);
+    apiGatewayList.forEach((apiGatewayId) => {
+      expect(apiGateways[apiGatewayId].Properties.MethodSettings).toBeTruthy();
+    });
+  });
 
-	it("Each API Gateway should have MethodSettings defined", () => {
-		const apiGateways = template.findResources("AWS::Serverless::Api");
-		const apiGatewayList = Object.keys(apiGateways);
-		apiGatewayList.forEach((apiGatewayId) => {
-			expect(apiGateways[apiGatewayId].Properties.MethodSettings).toBeTruthy();
-		});
-	});
+  it("There are 17 lambdas defined, all with at least one specific permission:", () => {
+    const lambdaCount = 17;
+    const lambdaPermissionCount = 18;
+    template.resourceCountIs("AWS::Serverless::Function", lambdaCount);
+    template.resourceCountIs("AWS::Lambda::Permission", lambdaPermissionCount);
+    expect(lambdaPermissionCount > lambdaCount);
+  });
 
-	it("There are 17 lambdas defined, all with a specific permission:", () => {
-		const lambdaCount = 17;
-		template.resourceCountIs("AWS::Serverless::Function", lambdaCount);
-		template.resourceCountIs("AWS::Lambda::Permission", lambdaCount);
-	});
+  it("All lambdas must have a FunctionName defined", () => {
+    const lambdas = template.findResources("AWS::Serverless::Function");
+    const lambdaList = Object.keys(lambdas);
+    lambdaList.forEach((lambda) => {
+      expect(lambdas[lambda].Properties.FunctionName).toBeTruthy();
+    });
+  });
 
-	it("All lambdas must have a FunctionName defined", () => {
-		const lambdas = template.findResources("AWS::Serverless::Function");
-		const lambdaList = Object.keys(lambdas);
-		lambdaList.forEach((lambda) => {
-			expect(lambdas[lambda].Properties.FunctionName).toBeTruthy();
-		});
-	});
+  it("All Lambdas must have an associated LogGroup named after their FunctionName.", () => {
+    const lambdas = template.findResources("AWS::Serverless::Function");
+    const lambdaList = Object.keys(lambdas);
+    lambdaList.forEach((lambda) => {
+      // These are functions we know are broken, but have to skip for now.
+      // They should be resolved and removed from this list ASAP.
+      const functionName = lambdas[lambda].Properties.FunctionName["Fn::Sub"];
+      console.log(functionName);
+      const expectedLogName = {
+        "Fn::Sub": `/aws/lambda/${functionName}`,
+      };
+      template.hasResourceProperties("AWS::Logs::LogGroup", {
+        LogGroupName: Match.objectLike(expectedLogName),
+      });
+    });
+  });
 
-	it("All Lambdas must have an associated LogGroup named after their FunctionName.", () => {
-		const lambdas = template.findResources("AWS::Serverless::Function");
-		const lambdaList = Object.keys(lambdas);
-		lambdaList.forEach((lambda) => {
-			// These are functions we know are broken, but have to skip for now.
-			// They should be resolved and removed from this list ASAP.
-			const functionName = lambdas[lambda].Properties.FunctionName["Fn::Sub"];
-			console.log(functionName);
-			const expectedLogName = {
-				"Fn::Sub": `/aws/lambda/${functionName}`,
-			};
-			template.hasResourceProperties("AWS::Logs::LogGroup", {
-				LogGroupName: Match.objectLike(expectedLogName),
-			});
-		});
-	});
+  it("Each log group defined must have a retention period", () => {
+    const logGroups = template.findResources("AWS::Logs::LogGroup");
+    const logGroupList = Object.keys(logGroups);
+    logGroupList.forEach((logGroup) => {
+      expect(logGroups[logGroup].Properties.RetentionInDays).toBeTruthy();
+    });
+  });
 
-	it("Each log group defined must have a retention period", () => {
-		const logGroups = template.findResources("AWS::Logs::LogGroup");
-		const logGroupList = Object.keys(logGroups);
-		logGroupList.forEach((logGroup) => {
-			expect(logGroups[logGroup].Properties.RetentionInDays).toBeTruthy();
-		});
-	});
+  it("Each regional API Gateway should have at least one custom domain base path mapping name defined", () => {
+    const gateways = template.findResources("AWS::Serverless::Api");
+    const gatewayList = Object.keys(gateways);
+    gatewayList.forEach((gateway) => {
+      template.hasResourceProperties("AWS::ApiGateway::BasePathMapping", {
+        RestApiId: {
+          Ref: gateway,
+        },
+      });
+    });
+  });
 
-	it("Each regional API Gateway should have at least one custom domain base path mapping name defined", () => {
-		const gateways = template.findResources("AWS::Serverless::Api");
-		const gatewayList = Object.keys(gateways);
-		gatewayList.forEach((gateway) => {
-			template.hasResourceProperties("AWS::ApiGateway::BasePathMapping", {
-				RestApiId: {
-					Ref: gateway,
-				}
-			});
-		});
-	});
+  it.skip("Each custom domain referenced in a BasePathMapping should be defined", () => {
+    const basePathMappings = template.findResources(
+      "AWS::ApiGateway::BasePathMapping",
+    );
+    const basePathMappingList = Object.keys(basePathMappings);
+    basePathMappingList.forEach((basePathMapping) => {
+      template.hasResourceProperties("AWS::ApiGateway::DomainName", {
+        DomainName: basePathMappings[basePathMapping].Properties.DomainName,
+      });
+    });
+  });
 
-	it.skip("Each custom domain referenced in a BasePathMapping should be defined", () => {
-		const basePathMappings = template.findResources("AWS::ApiGateway::BasePathMapping");
-		const basePathMappingList = Object.keys(basePathMappings);
-		basePathMappingList.forEach((basePathMapping) => {
-			template.hasResourceProperties("AWS::ApiGateway::DomainName", {
-				DomainName: basePathMappings[basePathMapping].Properties.DomainName
-			});
-		});
-	});
+  it.skip("should define a DNS record for each custom domain", () => {
+    const customDomainNames = template.findResources(
+      "AWS::ApiGateway::DomainName",
+    );
+    const customDomainNameList = Object.keys(customDomainNames);
+    customDomainNameList.forEach((customDomainName) => {
+      template.hasResourceProperties("AWS::Route53::RecordSet", {
+        Name: customDomainNames[customDomainName].Properties.DomainName,
+      });
+    });
+  });
 
-	it.skip("should define a DNS record for each custom domain", () => {
-		const customDomainNames = template.findResources("AWS::ApiGateway::DomainName");
-		const customDomainNameList = Object.keys(customDomainNames);
-		customDomainNameList.forEach((customDomainName) => {
-			template.hasResourceProperties("AWS::Route53::RecordSet", {
-				Name: customDomainNames[customDomainName].Properties.DomainName
-			});
-		});
-	});
+  it("should define an output with the API Gateway ID", () => {
+    template.hasOutput("F2FApiGatewayId", {
+      Value: {
+        "Fn::Sub": "${F2FRestApi}",
+      },
+    });
+  });
 
-	it("should define an output with the API Gateway ID", () => {
-		template.hasOutput("F2FApiGatewayId", {
-			Value: {
-				"Fn::Sub": "${F2FRestApi}",
-			},
-		});
-	});
+  it("should define an output with the F2F Backend URL using the custom domain name", () => {
+    template.hasOutput("F2FBackendURL", {
+      Value: {
+        "Fn::Sub": [
+          "https://${CustomDomainName}",
+          {
+            CustomDomainName: {
+              Ref: "F2FApiCustomDomainName",
+            },
+          },
+        ],
+      },
+    });
+  });
 
-	it("should define an output with the F2F Backend URL using the custom domain name", () => {
-		template.hasOutput("F2FBackendURL", {
-			Value: {
-				"Fn::Sub": [
-					"https://${CustomDomainName}",
-					{
-						CustomDomainName: {
-							Ref: "F2FApiCustomDomainName"
-						},
-					},
-				],
-			},
-		});
-	});
-
-	describe("Log group retention", () => {
-		it.each`
-    environment      | retention
-    ${"dev"}         | ${3}
-    ${"build"}       | ${3}
-    ${"staging"}     | ${3}
-    ${"integration"} | ${30}
-    ${"production"}  | ${30}
-  `(
-			"Log group retention period for $environment has correct value in mappings",
-			({ environment, retention }) => {
-				const mappings = template.findMappings("EnvironmentConfiguration");
-				expect(
-					mappings.EnvironmentConfiguration[environment].logretentionindays,
-				).toBe(retention);
-			},
-		);
-	});
+  describe("Log group retention", () => {
+    it.each`
+      environment      | retention
+      ${"dev"}         | ${3}
+      ${"build"}       | ${3}
+      ${"staging"}     | ${3}
+      ${"integration"} | ${30}
+      ${"production"}  | ${30}
+    `(
+      "Log group retention period for $environment has correct value in mappings",
+      ({ environment, retention }) => {
+        const mappings = template.findMappings("EnvironmentConfiguration");
+        expect(
+          mappings.EnvironmentConfiguration[environment].logretentionindays,
+        ).toBe(retention);
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Proposed changes
Allows the IAM Role assumed by the CodePipeline testing stage to invoke the ExpiredSession Function, enabling automated testing.

### What changed
Resource-based permissions to allow Lambda:invoke on the ExpiresSession Function granted to the deployment pipeline `TestRole`.

### Why did it change
Enable automated testing as part of the deployment pipeline

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-902

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
