### PR TITLE
KIWI-1947 - Add missing govuk_signin_journey_id field in F2F_CRI_SESSION_ABORTED Event

### DIFF
--- a/src/services/AbortRequestProcessor.ts
+++ b/src/services/AbortRequestProcessor.ts
@@ -80,11 +80,11 @@ export class AbortRequestProcessor {
   	}
 
   	try {
-		const coreEventFields = buildCoreEventFields(
-			f2fSessionInfo,
-			this.environmentVariables.issuer() as string,
-			f2fSessionInfo.clientIpAddress,
-		);
+  		const coreEventFields = buildCoreEventFields(
+  			f2fSessionInfo,
+  			this.environmentVariables.issuer() as string,
+  			f2fSessionInfo.clientIpAddress,
+  		);
   		await this.f2fService.sendToTXMA({
   			event_name: TxmaEventNames.F2F_CRI_SESSION_ABORTED,
   			...coreEventFields,

--- a/src/services/AbortRequestProcessor.ts
+++ b/src/services/AbortRequestProcessor.ts
@@ -80,9 +80,18 @@ export class AbortRequestProcessor {
   	}
 
   	try {
+		const coreEventFields = buildCoreEventFields(
+			f2fSessionInfo,
+			this.environmentVariables.issuer(),
+			f2fSessionInfo.clientIpAddress,
+		);
   		await this.f2fService.sendToTXMA({
   			event_name: TxmaEventNames.F2F_CRI_SESSION_ABORTED,
-  			...buildCoreEventFields(f2fSessionInfo, this.environmentVariables.issuer() as string, f2fSessionInfo.clientIpAddress),
+			...coreEventFields,
+			user: {
+				...coreEventFields.user,
+				govuk_signin_journey_id: f2fSessionInfo.clientSessionId,
+			},
   		}, encodedHeader);
   	} catch (error) {
   		this.logger.error("Auth session successfully aborted. Failed to send F2F_CRI_SESSION_ABORTED event to TXMA", {

--- a/src/services/AbortRequestProcessor.ts
+++ b/src/services/AbortRequestProcessor.ts
@@ -80,11 +80,11 @@ export class AbortRequestProcessor {
   	}
 
   	try {
-  		const coreEventFields = buildCoreEventFields(
-  			f2fSessionInfo,
-  			this.environmentVariables.issuer(),
-  			f2fSessionInfo.clientIpAddress,
-  		);
+		const coreEventFields = buildCoreEventFields(
+			f2fSessionInfo,
+			this.environmentVariables.issuer() as string,
+			f2fSessionInfo.clientIpAddress,
+		);
   		await this.f2fService.sendToTXMA({
   			event_name: TxmaEventNames.F2F_CRI_SESSION_ABORTED,
   			...coreEventFields,

--- a/src/services/AbortRequestProcessor.ts
+++ b/src/services/AbortRequestProcessor.ts
@@ -80,18 +80,18 @@ export class AbortRequestProcessor {
   	}
 
   	try {
-		const coreEventFields = buildCoreEventFields(
-			f2fSessionInfo,
-			this.environmentVariables.issuer(),
-			f2fSessionInfo.clientIpAddress,
-		);
+  		const coreEventFields = buildCoreEventFields(
+  			f2fSessionInfo,
+  			this.environmentVariables.issuer(),
+  			f2fSessionInfo.clientIpAddress,
+  		);
   		await this.f2fService.sendToTXMA({
   			event_name: TxmaEventNames.F2F_CRI_SESSION_ABORTED,
-			...coreEventFields,
-			user: {
-				...coreEventFields.user,
-				govuk_signin_journey_id: f2fSessionInfo.clientSessionId,
-			},
+  			...coreEventFields,
+  			user: {
+  				...coreEventFields.user,
+  				govuk_signin_journey_id: f2fSessionInfo.clientSessionId,
+  			},
   		}, encodedHeader);
   	} catch (error) {
   		this.logger.error("Auth session successfully aborted. Failed to send F2F_CRI_SESSION_ABORTED event to TXMA", {

--- a/src/tests/data/F2F_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/src/tests/data/F2F_CRI_SESSION_ABORTED_SCHEMA.json
@@ -15,12 +15,16 @@
         },
         "ip_address": {
           "type": "string"
+        },
+        "govuk_signin_journey_id": {
+            "type": "string"
         }
       },
       "required": [
         "user_id",
         "session_id",
-        "ip_address"
+        "ip_address",
+        "govuk_signin_journey_id"
       ]
     },
     "timestamp": {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/817b8f24-e49b-4ec8-b01c-d5e359f8ed1e)
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/73e1ebee-ce4b-4f1b-9d58-4fef0ccad67f">


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Add missing govuk_signin_journey_id field in F2F_CRI_SESSION_ABORTED

### Why did it change

Issue raised where user triggered event F2F_CRI_SESSION_ABORTED on a front end staging stub and have found that the inbound event does not contain a "$.user.govuk_signin_journey_id" value

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1947](https://govukverify.atlassian.net/browse/KIWI-1947)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1947]: https://govukverify.atlassian.net/browse/KIWI-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ