### PR TITLE
Fix for ExpiredSession Function test action invoke permission

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3237,7 +3237,7 @@ Resources:
 
   ExpiredSessionFunctionTestRolePermission:
     Type: AWS::Lambda::Permission
-    Condition: IsNotProdLikeEnvironment
+    Condition: AddExpiredSessionFunctionTestRolePermissions
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !Ref ExpiredSessionsFunction


### PR DESCRIPTION
### What changed

Amended condition for ExpiredSession Function test action invoke permission.

### Why did it change

This was mistakenly changed during an [unrelated PR here.](https://github.com/govuk-one-login/ipv-cri-f2f-api/pull/544/files#diff-aa838e3312dccda3e0f52cfcf60738f956197278c3330ed38f1cbc8cd9e977d1L3240)

Condition was originally added [here](https://github.com/govuk-one-login/ipv-cri-f2f-api/pull/552/files#diff-aa838e3312dccda3e0f52cfcf60738f956197278c3330ed38f1cbc8cd9e977d1R3096)