### PR TITLE
Add CloudWatch Alarms tests Infra test run

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -6320,6 +6320,8 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger the alarm if any lambda in the account timesout 5 times within 5 minutes. ${SupportManualURL}"
       AlarmName: !Sub "${AWS::StackName}-LambdaTimeoutAlarm"

--- a/src/tests/infra/template.test.ts
+++ b/src/tests/infra/template.test.ts
@@ -161,6 +161,83 @@ describe("Infra", () => {
     });
   });
 
+  it("should define CloudWatch alarms", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		expect(Object.keys(alarms).length).toBeGreaterThan(0);
+	});
+
+	it("Each CloudWatch alarm should have an AlarmName defined", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		const alarmList = Object.keys(alarms);
+		alarmList.forEach((alarmId) => {
+			expect(alarms[alarmId].Properties.AlarmName).toBeTruthy();
+		});
+	});
+
+	it("Each CloudWatch alarm should have Metrics defined if TreatMissingData is not 'notBreaching'", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		const alarmList = Object.keys(alarms);
+
+		alarmList.forEach((alarmId) => {
+			const properties = alarms[alarmId].Properties;
+			if (properties.TreatMissingData !== "notBreaching") {
+				expect(properties.Metrics).toBeTruthy();
+			}
+		});
+	});
+
+	it("Each CloudWatch alarm should have a ComparisonOperator defined", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		const alarmList = Object.keys(alarms);
+		alarmList.forEach((alarmId) => {
+			expect(alarms[alarmId].Properties.ComparisonOperator).toBeTruthy();
+		});
+	});
+
+	it("Each CloudWatch alarm should have a Threshold defined", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		const alarmList = Object.keys(alarms);
+		alarmList.forEach((alarmId) => {
+			expect(alarms[alarmId].Properties.Threshold).toBeTruthy();
+		});
+	});
+
+	it("Each CloudWatch alarm should have an EvaluationPeriods defined", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		const alarmList = Object.keys(alarms);
+		alarmList.forEach((alarmId) => {
+			expect(alarms[alarmId].Properties.EvaluationPeriods).toBeTruthy();
+		});
+	});
+
+	it("Each CloudWatch alarm should have an AlarmActions defined", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		const alarmList = Object.keys(alarms);
+		alarmList.forEach((alarmId) => {
+			expect(alarms[alarmId].Properties.AlarmActions).toBeTruthy();
+		});
+	});
+
+	it("Each CloudWatch alarm should have OKActions defined", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		const alarmList = Object.keys(alarms);
+		alarmList.forEach((alarmId) => {
+			expect(alarms[alarmId].Properties.OKActions).toBeTruthy();
+		});
+	});
+
+
+	it("All CloudWatch alarms should have InsufficientDataActions and DatapointsToAlarm if TreatMissingData is not 'notBreaching'", () => {
+		const alarms = template.findResources("AWS::CloudWatch::Alarm");
+		Object.keys(alarms).forEach((alarmKey) => {
+			const alarm = alarms[alarmKey];
+			if (alarm.Properties.TreatMissingData !== "notBreaching") {
+				expect(alarm.Properties.InsufficientDataActions).toBeDefined();
+				expect(alarm.Properties.DatapointsToAlarm).toBeDefined();
+			}
+		});
+	});
+
   describe("Log group retention", () => {
     it.each`
       environment      | retention


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Refactored alarm tests, moved to infra tests so we're validating the alarms config in the template.yml 

Checks for the presence of the following fields in all alarms: 

- AlarmName
- Metrics if TreatMissingData is not 'notBreaching'
- ComparisonOperator
- Threshold
- EvaluationPeriods
- AlarmActions
- OKActions
- InsufficientDataActions and DatapointsToAlarm if TreatMissingData is not 'notBreaching'

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1910](https://govukverify.atlassian.net/browse/KIWI-1910)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1910]: https://govukverify.atlassian.net/browse/KIWI-1910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ