### PR TITLE
Successfully set AWS cloudwatch log retention to 30 days

### DIFF
--- a/deploy/samconfig.toml
+++ b/deploy/samconfig.toml
@@ -2,8 +2,8 @@ version = 0.1
 [dev]
 [dev.deploy]
 [dev.deploy.parameters]
-stack_name = "f2f-cri-api"
-s3_prefix = "f2f-cri-api"
+stack_name = "f2f-cri-api-1872"
+s3_prefix = "f2f-cri-api-1872"
 region = "eu-west-2"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -72,15 +72,15 @@ Mappings:
   EnvironmentConfiguration: # This is where you store per-environment settings.
     dev:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
-      logretentionindays: 3
+      logretentionindays: 30
       apiTracingEnabled: true
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
-      logretentionindays: 3
+      logretentionindays: 30
       apiTracingEnabled: true
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret
-      logretentionindays: 3
+      logretentionindays: 30
       apiTracingEnabled: true
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables #pragma: allowlist secret


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
[ KIWI-1872 ] Set AWS CloudWatch log retention to 30 days

### Proposed changes

### What changed

Updated the CloudFormation template to set the retention period for all CloudWatch log groups to 30 days (1 month)
Modified the EnvironmentConfiguration mapping in the template to ensure consistent 30-day retention across all environments (dev, build, staging, integration, production)
Applied the change to all Lambda function and API Gateway log groups associated with the CIC API stack

### Why did it change

To standardise log retention periods across all environments
To ensure compliance with data retention policies

Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

[INCIDEN-627](https://govukverify.atlassian.net/browse/INCIDEN-627?focusedCommentId=125675)

### Checklists

PII logging

- [x] Verified that no PII data is being logged

Environment variables or secrets
<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

[INCIDEN-627]: https://govukverify.atlassian.net/browse/INCIDEN-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/d7ad684a-8d09-417d-9143-b7dc69a73ef7">
