### PR TITLE
KIWI-1958: Added sonar action for main branch

### DIFF
--- a/.github/workflows/pull-request-sonar.yml
+++ b/.github/workflows/pull-request-sonar.yml
@@ -31,10 +31,10 @@ jobs:
         run: npm install
       - name: Test and coverage
         run: npm run test:unit -- --coverage
-      - name: "Run SonarCloud Scan"
-        if: ${{ success() && github.actor != 'dependabot[bot]' }}
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run SonarCloud scan
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@cd7d35dde348251237efbbaee5345e95adef0321
+        with:
+          coverage-location: src/coverage/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,0 +1,58 @@
+name: Unit tests
+
+on:
+  workflow_call:
+    inputs:
+      coverage-report: { type: boolean, required: false, default: false }
+      coverage-artifact: { type: string, required: false, default: coverage }
+    outputs:
+      coverage-artifact:
+        value: ${{ inputs.coverage-artifact }}
+
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./src/
+
+permissions: {}
+
+jobs:
+  run-tests:
+    name: Unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull repository
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Set offline mirror path
+        id: offline-mirror-path
+        run: echo "mirror-dir=${GITHUB_WORKSPACE}/npm-packages-offline-cache" >> $GITHUB_OUTPUT
+
+      - name: Cache npm offline-mirror
+        uses: actions/cache@v4
+        with:
+         path: ${{ steps.offline-mirror-path.outputs.mirror-dir }}
+         key: offline-mirror-oauth
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Unit tests
+        run: npm run test:unit
+
+      - name: Archive coverage results
+        if: ${{ inputs.coverage-report }}
+        uses: actions/upload-artifact@v3
+        with:
+         name: ${{ inputs.coverage-artifact }}
+         retention-days: 3
+         path: src/coverage/lcov.info

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -1,0 +1,45 @@
+name: Scan repository
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Every Monday at 9am
+    - cron: "0 9 * * 1"
+
+concurrency:
+  group: scan-repo-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:         
+    unit-tests:
+      name: Test coverage
+      uses: ./.github/workflows/run-unit-tests.yml
+      with:
+        coverage-report: true
+
+    sonarcloud:
+        name: SonarCloud
+        needs: unit-tests
+        runs-on: ubuntu-latest
+        steps:
+        - name: Run SonarCloud scan
+          uses: govuk-one-login/github-actions/code-quality/sonarcloud@cd7d35dde348251237efbbaee5345e95adef0321
+          with:
+            coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            sonar-token: ${{ secrets.SONAR_TOKEN }}
+
+    codeql:
+        name: CodeQL
+        runs-on: ubuntu-latest
+        permissions:
+          security-events: write
+        steps:
+        - name: Run CodeQL scan
+          uses: govuk-one-login/github-actions/code-quality/codeql@cd7d35dde348251237efbbaee5345e95adef0321
+          with:
+            languages: javascript-typescript

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 .env
 .idea/
 cf-output.txt
+
+.gradle
+build/
+lambdas/
+lib/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.sources=src/
 sonar.exclusions=src/tests/**/*.*,src/jest.config.ts,src/jest.setup.ts
 sonar.tests=src/
 sonar.test.inclusions=**/*.test.ts
-sonar.javascript.lcov.reportPaths=src/coverage/lcov.info
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2020",
     "strict": true,
     "preserveConstEnums": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Proposed changes

### What changed

Added github actions to run sonar on pushes to main

### Why did it change

So that we can effectively monitor Kiwi services
