### PR TITLE
KIWI-1987: Integer maxLength test

### DIFF
--- a/deploy/f2f-spec.yaml
+++ b/deploy/f2f-spec.yaml
@@ -1268,12 +1268,16 @@ components:
                   type: number
                   description: latitude for the Post Office location
                   example: 0.34322
-                  maxLength: 60
+                  minimum: -90
+                  maximum: 90
+                  multipleOf: 0.0000000001
                 longitude:
                   type: number
                   description: longitude for the Post Office location
                   example: -42.48372
-                  maxLength: 60
+                  minimum: -180
+                  maximum: 180
+                  multipleOf: 0.0000000001
             post_code:
               type: string
               description: Post code of post office

--- a/deploy/f2f-spec.yaml
+++ b/deploy/f2f-spec.yaml
@@ -1270,14 +1270,12 @@ components:
                   example: 0.34322
                   minimum: -90
                   maximum: 90
-                  multipleOf: 0.0000000001
                 longitude:
                   type: number
                   description: longitude for the Post Office location
                   example: -42.48372
                   minimum: -180
                   maximum: 180
-                  multipleOf: 0.0000000001
             post_code:
               type: string
               description: Post code of post office


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Add max length validation to integers in /documentSelection Payload (longitude + latitude) 

Latitude: 
minimum: -90
maximum: 90
multipleOf: 0.0000000001 (max 10 decimal places) **REMOVED**


Longitude:
minimum: -180
maximum: 180
multipleOf: 0.0000000001 (max 10 decimal places)  **REMOVED**

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1987](https://govukverify.atlassian.net/browse/KIWI-1987)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-1987]: https://govukverify.atlassian.net/browse/KIWI-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ