### PR TITLE
PSREDEV-1911-dev-platform-support-request-adam-higginson

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Archive coverage results
         if: ${{ inputs.coverage-report }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
          name: ${{ inputs.coverage-artifact }}
          retention-days: 3

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -14,7 +14,7 @@ concurrency:
 
 permissions: read-all
 
-jobs:         
+jobs:
     unit-tests:
       name: Test coverage
       uses: ./.github/workflows/run-unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - name: Run SonarCloud scan
-          uses: govuk-one-login/github-actions/code-quality/sonarcloud@cd7d35dde348251237efbbaee5345e95adef0321
+          uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
           with:
             coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
             github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: detect-private-key
       - id: detect-aws-credentials
@@ -20,36 +20,36 @@ repos:
       - id: remove-tabs
       - id: remove-crlf
   - repo: https://github.com/mattlqx/pre-commit-search-and-replace
-    rev: v1.1.2
+    rev: v1.1.8
     hooks:
       - id: search-and-replace
-        stages: [commit-msg, commit]
+        stages: [commit-msg, pre-commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.16.0
+    rev: v9.18.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         args: ['--verbose']
         verbose: true  # print warnings
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '3.2.112'
+    rev: '3.2.296'
     hooks:
       - id: checkov
         verbose: true
         args: [--soft-fail]
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.55.0
+    rev: v9.14.0
     hooks:
       - id: eslint
         files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
         types: [file]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types_or: ["javascript", "ts", "json"]
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.83.5
+    rev: v1.19.0
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/.pre-commit-search-and-replace.yaml
+++ b/.pre-commit-search-and-replace.yaml
@@ -1,0 +1,2 @@
+- search: A Replacement String
+  replacement: A Good String


### PR DESCRIPTION
EOL on the 5th December 2024

Also updated version of Sonar Cloud as it needs to use download-artifact v4 as well

The Search and Replace pre-commit hook was failing due to 
empty config so I put in a placeholder

https://govukverify.atlassian.net/browse/PSREDEV-1911

## Proposed changes
https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new
https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new

### What changed

Updated GH actions

### Why did it change

V3 being EOLed 5th Dec

### Issue tracking
https://govukverify.atlassian.net/browse/PSREDEV-1911