### PR TITLE
Update Third Party Traffic Script to skip Unhappy Path Tests

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -49,7 +49,7 @@
     "test:api-traffic": "npm run compile && npm run api-traffic",
     "api-third-party": "THIRD_PARTY_CLIENT_ID=SandboxJourneyFlow JEST_JUNIT_OUTPUT_NAME=third-party-api-report.xml ./node_modules/.bin/jest --testMatch '**/tests/api/backend/**/*Path.test.ts'",
     "test:api-third-party": "npm run compile && npm run api-third-party",
-    "api-third-party-traffic": "THIRD_PARTY_CLIENT_ID=SandboxJourneyFlow JEST_JUNIT_OUTPUT_NAME=third-party-api-report.xml ./node_modules/.bin/jest --testPathPattern='tests/api/backend/(HappyPath|CallbackApi)\\.test\\.ts$'",
+    "api-third-party-traffic": "THIRD_PARTY_CLIENT_ID=SandboxJourneyFlow JEST_JUNIT_OUTPUT_NAME=third-party-api-report.xml ./node_modules/.bin/jest --testPathPattern=tests/api/backend/HappyPath.test.ts",
     "test:api-third-party-traffic": "npm run compile && npm run api-third-party-traffic",
     "yoti": "JEST_JUNIT_OUTPUT_NAME=api-report.xml ./node_modules/.bin/jest --runInBand --testPathPattern=tests/api/stub/YotiStub.test.ts",
     "test:yoti": "npm run compile && npm run yoti",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove Callback tests from api-third-party-traffic script

### Why did it change

Callback tests incorrectly added to npm run script

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
