### PR TITLE
IPS-1247: Run tests in serial as parallel tests causes 5xx error

### DIFF
--- a/traffic-tests/run-tests.sh
+++ b/traffic-tests/run-tests.sh
@@ -48,14 +48,11 @@ case "$SAM_STACK_NAME" in
 
         export DEV_F2F_PERSON_IDENTITY_TABLE_NAME=$(remove_quotes "$CFN_PersonIdentityTableName")
 
-        run_tests "test:api-traffic" "test:api-third-party-traffic" &
-        sleep 10
-        run_tests "test:api-traffic" "test:api-third-party-traffic" &
-        sleep 10
-        run_tests "test:api-traffic" "test:api-third-party-traffic" &
-        sleep 10
-        run_tests "test:api-traffic" "test:api-third-party-traffic" &
-        wait
+        run_tests "test:api-traffic" "test:api-third-party-traffic"
+        sleep 2
+        run_tests "test:api-traffic" "test:api-third-party-traffic"
+        sleep 2
+        run_tests "test:api-traffic" "test:api-third-party-traffic"
 
         error_code=$?
         ;;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed
- Running api test in parallel causes random 5xx errors. The issue is caused intermittently due to which some inconsistencies in the deployment. 
- Added the tests in serial to run the time of deployment which on running 4 times for around 10 minutes for the deployment duration.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- Changed the tests to serial as often caused 5xx error. 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1247](https://govukverify.atlassian.net/browse/IPS-1247)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1247]: https://govukverify.atlassian.net/browse/IPS-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ