### PR TITLE
[KIWI-2124] - F2F | PCL | BE | Adding Feature flag to TxMA event extension

### DIFF
--- a/src/services/SendToGovNotifyService.ts
+++ b/src/services/SendToGovNotifyService.ts
@@ -291,6 +291,7 @@ export class SendToGovNotifyService {
   				event_name: TxmaEventNames.F2F_YOTI_PDF_LETTER_POSTED,
   				...coreEventFields,
   				extensions: {
+  					differentPostalAddress: f2fPersonInfo.addresses.length > 1 ? "true" : "false",
   					evidence: [
   						{
   							txn: f2fSessionInfo.yotiSessionId ?? "",

--- a/src/services/SendToGovNotifyService.ts
+++ b/src/services/SendToGovNotifyService.ts
@@ -291,7 +291,7 @@ export class SendToGovNotifyService {
   				event_name: TxmaEventNames.F2F_YOTI_PDF_LETTER_POSTED,
   				...coreEventFields,
   				extensions: {
-  					differentPostalAddress: f2fPersonInfo.addresses.length > 1 ? "true" : "false",
+  					differentPostalAddress: f2fPersonInfo.addresses.length > 1 ? true : false,
   					evidence: [
   						{
   							txn: f2fSessionInfo.yotiSessionId ?? "",

--- a/src/tests/unit/services/SendToGovNotifyService.test.ts
+++ b/src/tests/unit/services/SendToGovNotifyService.test.ts
@@ -380,7 +380,7 @@ describe("SendToGovNotifyService", () => {
 		expect(emailResponse.emailFailureMessage).toBe("");
 	});
 
-	it("send F2F_YOTI_PDF_LETTER_POSTED TxMA event with differentPostalAddress set to true if the user has a second postal address", async () => {
+	it("send F2F_YOTI_PDF_LETTER_POSTED TxMA event with differentPostalAddress set to true if the user has selected a different postal address", async () => {
 		const mockEmailResponse = new EmailResponse(new Date().toISOString(), "test", 201);
 		const session = getMockSessionItem();
 		const person = getMockPersonItem("PRINTED_LETTER_DIFFERENT_ADDRESS");

--- a/src/tests/unit/services/SendToGovNotifyService.test.ts
+++ b/src/tests/unit/services/SendToGovNotifyService.test.ts
@@ -329,6 +329,7 @@ describe("SendToGovNotifyService", () => {
 			timestamp,
 			event_timestamp_ms: timestamp * 1000,
 			extensions: {
+				differentPostalAddress: "false",
 				evidence: [
 					{
 						txn: "b988e9c8-47c6-430c-9ca3-8cdacd85ee91",

--- a/src/tests/unit/services/SendToGovNotifyService.test.ts
+++ b/src/tests/unit/services/SendToGovNotifyService.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable max-depth */
 /* eslint-disable max-lines */
@@ -60,7 +61,7 @@ function getMockSessionItem(): ISessionItem {
 	return session;
 }
 
-function getMockPersonItem(userPdfPreference: string): PersonIdentityItem {
+function getMockPersonItem(communicationPreference: string): PersonIdentityItem {
 	const personEmail: PersonIdentityItem = {
 		addresses: [
 			{
@@ -126,9 +127,9 @@ function getMockPersonItem(userPdfPreference: string): PersonIdentityItem {
 		],
 	};
 
-	if (userPdfPreference === "PRINTED_LETTER") {
+	if (communicationPreference === "letter") {
 		return personPost;
-	} else if (userPdfPreference === "PRINTED_LETTER_DIFFERENT_ADDRESS") {
+	} else if (communicationPreference === "letterDifferentAddress") {
 		return personPostDifferentAddress;
 	} else {
 		return personEmail;
@@ -166,7 +167,7 @@ describe("SendToGovNotifyService", () => {
 	it("Returns EmailResponse when YOTI PDF email is sent successfully", async () => {
 		const mockEmailResponse = new EmailResponse(new Date().toISOString(), "test", 201);
 		const session = getMockSessionItem();
-		const person = getMockPersonItem("EMAIL_ONLY");
+		const person = getMockPersonItem("email");
 		const encoded = "gwegwtb";
 		mockF2fService.getSessionById.mockResolvedValue(session);
 		mockF2fService.getPersonIdentityById.mockResolvedValue(person);
@@ -217,7 +218,7 @@ describe("SendToGovNotifyService", () => {
 			},
 		});
 		const session = getMockSessionItem();
-		const person = getMockPersonItem("EMAIL_ONLY");
+		const person = getMockPersonItem("email");
 		const encoded = "gwegwtb";
 		mockF2fService.getSessionById.mockResolvedValue(session);
 		mockF2fService.getPersonIdentityById.mockResolvedValue(person);
@@ -231,7 +232,7 @@ describe("SendToGovNotifyService", () => {
 	it("SendToGovNotifyService retries when GovNotify throws a 500 error", async () => {
 		jest.useRealTimers();
 		const session = getMockSessionItem();
-		const person = getMockPersonItem("EMAIL_ONLY");
+		const person = getMockPersonItem("email");
 		const encoded = "gwegwtb";
 		mockF2fService.getSessionById.mockResolvedValue(session);
 		mockF2fService.getPersonIdentityById.mockResolvedValue(person);
@@ -257,7 +258,7 @@ describe("SendToGovNotifyService", () => {
 	it("SendToGovNotifyService retries when GovNotify throws a 429 error", async () => {
 		jest.useRealTimers();
 		const session = getMockSessionItem();
-		const person = getMockPersonItem("EMAIL_ONLY");
+		const person = getMockPersonItem("email");
 		const encoded = "gwegwtb";
 		mockF2fService.getSessionById.mockResolvedValue(session);
 		mockF2fService.getPersonIdentityById.mockResolvedValue(person);
@@ -282,7 +283,7 @@ describe("SendToGovNotifyService", () => {
     
 	it("Returns EmailResponse when email is sent successfully and write to TxMA fails", async () => {
 		const session = getMockSessionItem();
-		const person = getMockPersonItem("EMAIL_ONLY");
+		const person = getMockPersonItem("email");
 		const encoded = "gwegwtb";
 		mockF2fService.getSessionById.mockResolvedValue(session);
 		mockF2fService.getPersonIdentityById.mockResolvedValue(person);
@@ -303,7 +304,7 @@ describe("SendToGovNotifyService", () => {
 	it("Returns EmailResponse when posted customer letter & YOTI PDF email is sent successfully", async () => {
 		const mockEmailResponse = new EmailResponse(new Date().toISOString(), "test", 201);
 		const session = getMockSessionItem();
-		const person = getMockPersonItem("PRINTED_LETTER");
+		const person = getMockPersonItem("email");
 		const encoded = "gwegwtb";
 		mockF2fService.getSessionById.mockResolvedValue(session);
 		mockF2fService.getPersonIdentityById.mockResolvedValue(person);
@@ -346,7 +347,7 @@ describe("SendToGovNotifyService", () => {
 			timestamp,
 			event_timestamp_ms: timestamp * 1000,
 			extensions: {
-				differentPostalAddress: "false",
+				differentPostalAddress: false,
 				evidence: [
 					{
 						txn: "b988e9c8-47c6-430c-9ca3-8cdacd85ee91",
@@ -383,7 +384,7 @@ describe("SendToGovNotifyService", () => {
 	it("send F2F_YOTI_PDF_LETTER_POSTED TxMA event with differentPostalAddress set to true if the user has selected a different postal address", async () => {
 		const mockEmailResponse = new EmailResponse(new Date().toISOString(), "test", 201);
 		const session = getMockSessionItem();
-		const person = getMockPersonItem("PRINTED_LETTER_DIFFERENT_ADDRESS");
+		const person = getMockPersonItem("letterDifferentAddress");
 		const encoded = "gwegwtb";
 		mockF2fService.getSessionById.mockResolvedValue(session);
 		mockF2fService.getPersonIdentityById.mockResolvedValue(person);
@@ -400,7 +401,7 @@ describe("SendToGovNotifyService", () => {
 			timestamp,
 			event_timestamp_ms: timestamp * 1000,
 			extensions: {
-				differentPostalAddress: "true",
+				differentPostalAddress: true,
 				evidence: [
 					{
 						txn: "b988e9c8-47c6-430c-9ca3-8cdacd85ee91",
@@ -435,7 +436,7 @@ describe("SendToGovNotifyService", () => {
 
 	it("Returns EmailResponse when posted customer letter fails but YOTI PDF email is sent successfully", async () => {
 		const session = getMockSessionItem();
-		const person = getMockPersonItem("PRINTED_LETTER");
+		const person = getMockPersonItem("letter");
 		const encoded = "gwegwtb";
 		mockF2fService.getSessionById.mockResolvedValue(session);
 		mockF2fService.getPersonIdentityById.mockResolvedValue(person);

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -78,7 +78,7 @@ export interface ExtensionObject {
 	"previous_govuk_signin_journey_id"?: string;
 	"post_office_details"?: PostOfficeDetails;
 	"post_office_visit_details"?: PostOfficeVisitDetails;
-	"differentPostalAddress"?: string;
+	"differentPostalAddress"?: boolean;
 }
 
 export interface TxmaEvent extends BaseTxmaEvent {

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -78,6 +78,7 @@ export interface ExtensionObject {
 	"previous_govuk_signin_journey_id"?: string;
 	"post_office_details"?: PostOfficeDetails;
 	"post_office_visit_details"?: PostOfficeVisitDetails;
+	"differentPostalAddress"?: string;
 }
 
 export interface TxmaEvent extends BaseTxmaEvent {


### PR DESCRIPTION
### What changed

Added differentPostalAddress property inside the extension field for the F2F_YOTI_PDF_LETTER_POSTED TxMA event to indicate whether the user has nominated a second address separate to their home address to have their customer letter sent to, or not

### Why did it change

Improved event clarity as it is now possible to see if the user has a second address outside of the restricted address field 

### Issue tracking

- [KIWI-2124](https://govukverify.atlassian.net/browse/KIWI-2124)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

![Screenshot 2025-01-29 at 11 54 56](https://github.com/user-attachments/assets/3831b058-c515-492a-aa74-8ec1d483a7d8)



[KIWI-2124]: https://govukverify.atlassian.net/browse/KIWI-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ