### PR TITLE
IPS-1247: Increase interval between 2 test instance

### DIFF
--- a/traffic-tests/run-tests.sh
+++ b/traffic-tests/run-tests.sh
@@ -49,9 +49,7 @@ case "$SAM_STACK_NAME" in
         export DEV_F2F_PERSON_IDENTITY_TABLE_NAME=$(remove_quotes "$CFN_PersonIdentityTableName")
 
         run_tests "test:api-traffic" "test:api-third-party-traffic"
-        sleep 2
-        run_tests "test:api-traffic" "test:api-third-party-traffic"
-        sleep 2
+        sleep 300
         run_tests "test:api-traffic" "test:api-third-party-traffic"
 
         error_code=$?


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
- Changes to run traffic tests during deployment

## Proposed changes
- Previously there were 3 instance of tests running in an interval of 2 seconds and this caused lot failures on both dev and build.
- In order to fix the issue, the interval between 2 tests instance is increased to 5minutes from 2 seconds.
- This will allow to start the second instance of test after the completion of the first tests. 

### What changed
- Increase the interval between tests to start the test after the completion for the first instance
- Also, number fo tests reduced to 2 instances

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- Frequent failure in the traffic tests causing deployment failure

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1247](https://govukverify.atlassian.net/browse/IPS-1247)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
