### PR TITLE
[KIWI-2124] - | PCL | BE | Adding Feature flag to TxMA event extension

### DIFF
--- a/src/services/SendToGovNotifyService.ts
+++ b/src/services/SendToGovNotifyService.ts
@@ -123,7 +123,7 @@ export class SendToGovNotifyService {
   			f2fSessionInfo.clientId,
   			this.logger,
   		);
-			
+
   		if (!clientConfig) {
   			this.logger.error("Unrecognised client in request", {
   				messageCode: MessageCodes.UNRECOGNISED_CLIENT,
@@ -132,7 +132,7 @@ export class SendToGovNotifyService {
   		}
 
   		const f2fPersonInfo = await this.f2fService.getPersonIdentityById(sessionId, this.environmentVariables.personIdentityTableName());
-		
+
 		  if (!f2fPersonInfo) {
   			this.logger.warn("Missing details in PERSON table", {
   				messageCode: MessageCodes.PERSON_NOT_FOUND,
@@ -159,18 +159,18 @@ export class SendToGovNotifyService {
 				  this.metrics.addMetric("SendToGovNotify_fetched_merged_pdf", MetricUnits.Count, 1);
 
   				if (mergedPdf) {
+
   					this.logger.debug("sendLetter", SendToGovNotifyService.name);
   					this.logger.info("Sending precompiled letter");
-
 					
   					await this.sendGovNotificationLetter(
   						mergedPdf,
   						referenceId,
   						govNotify,
   					);
+
   					await this.sendF2FLetterSentEvent(f2fSessionInfo, f2fPersonInfo);
   				}
-
   			} catch (err: any) {
   				this.logger.error("sendYotiInstructions - Cannot send letter", {
   					message: err, messageCode: MessageCodes.FAILED_TO_SEND_PDF_LETTER,
@@ -296,6 +296,7 @@ export class SendToGovNotifyService {
   				event_name: TxmaEventNames.F2F_YOTI_PDF_LETTER_POSTED,
   				...coreEventFields,
   				extensions: {
+  				differentPostalAddress: f2fPersonInfo.addresses.length > 1 ? true : false,
   					evidence: [
   						{
   							txn: f2fSessionInfo.yotiSessionId ?? "",
@@ -431,10 +432,7 @@ export class SendToGovNotifyService {
 
   			const letterResponse = await govNotify.sendPrecompiledLetter(`${referenceId}-letter`, pdf);
 
-  			const { data } = letterResponse;
-
-			
-  			this.logger.info("Letter notification_id = " + data.id);
+  			this.logger.info("Letter notification_id = " + letterResponse.id);
   			const singleMetric = this.metrics.singleMetric();
   			singleMetric.addDimension("status_code", letterResponse.status.toString());
   			singleMetric.addMetric("SendToGovNotify_notify_letter_response", MetricUnits.Count, 1);
@@ -444,9 +442,10 @@ export class SendToGovNotifyService {
   			this.logger.info(
   				"sendLetter - response status after sending letter",
   				SendToGovNotifyService.name,
-  				letterResponse.status,
+  				letterResponse,
   			);
-  			return letterResponse.status;
+
+  			return letterResponse;
   		} catch (err: any) {
   			this.logger.error("sendLetter- GOV UK Notify threw an error");
 

--- a/src/utils/TxmaEvent.ts
+++ b/src/utils/TxmaEvent.ts
@@ -78,6 +78,7 @@ export interface ExtensionObject {
 	"previous_govuk_signin_journey_id"?: string;
 	"post_office_details"?: PostOfficeDetails;
 	"post_office_visit_details"?: PostOfficeVisitDetails;
+	"differentPostalAddress"?: boolean;
 }
 
 export interface TxmaEvent extends BaseTxmaEvent {


### PR DESCRIPTION
### What changed

Added differentPostalAddress property inside the extension field for the F2F_YOTI_PDF_LETTER_POSTED TxMA event to indicate whether the user has nominated a second address separate to their home address to have their customer letter sent to, or not

### Why did it change

Improved event clarity as it is now possible to see if the user has a second address outside of the restricted address field 

### Issue tracking

- [KIWI-2124](https://govukverify.atlassian.net/browse/KIWI-2124)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

![Screenshot 2025-01-29 at 11 54 56](https://github.com/user-attachments/assets/3831b058-c515-492a-aa74-8ec1d483a7d8)



[KIWI-2124]: https://govukverify.atlassian.net/browse/KIWI-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ