### PR TITLE
Fix to tests added as part of KIWI-2124

### DIFF
--- a/src/tests/api/backend/HappyPath.test.ts
+++ b/src/tests/api/backend/HappyPath.test.ts
@@ -18,6 +18,7 @@ import {
 	personInfoGet,
 	personInfoKeyGet,
 	validatePersonInfoResponse,
+	initiateUserInfo,
 } from "../ApiTestSteps";
 import { getTxmaEventsFromTestHarness, invokeLambdaFunction, validateTxMAEventData } from "../ApiUtils";
 import f2fStubPayload from "../../data/exampleStubPayload.json";
@@ -146,9 +147,7 @@ describe("/documentSelection Endpoint", () => {
 		const newf2fStubPayload = structuredClone(f2fStubPayload);
 		const { sessionId } = await startStubServiceAndReturnSessionId(newf2fStubPayload);
 
-
-		const postResponse = await postDocumentSelection(docSelectionData, sessionId);
-		expect(postResponse.status).toBe(200);
+		await initiateUserInfo(docSelectionData, sessionId);
 
 		const personIdentityRecord = await getPersonIdentityRecordById(sessionId, constants.DEV_F2F_PERSON_IDENTITY_TABLE_NAME);
 		expect(personIdentityRecord?.pdfPreference).toBe(docSelectionData.pdf_preference);
@@ -163,11 +162,10 @@ describe("/documentSelection Endpoint", () => {
 		const newf2fStubPayload = structuredClone(f2fStubPayload);
 		const { sessionId } = await startStubServiceAndReturnSessionId(newf2fStubPayload);
 
-
 		const docSelect = structuredClone(docSelectionData);
 		docSelect.postal_address.preferredAddress = true;
-		const postResponse = await postDocumentSelection(docSelectionData, sessionId);
-		expect(postResponse.status).toBe(200);
+
+		await initiateUserInfo(docSelectionData, sessionId);
 
 		const personIdentityRecord = await getPersonIdentityRecordById(sessionId, constants.DEV_F2F_PERSON_IDENTITY_TABLE_NAME);
 
@@ -179,7 +177,6 @@ describe("/documentSelection Endpoint", () => {
 
 		const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 4);
 		validateTxMAEventData({ eventName: "F2F_YOTI_PDF_LETTER_POSTED", schemaName: "F2F_YOTI_PDF_LETTER_POSTED_SCHEMA" }, allTxmaEventBodies);
-
 	});
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

No longer trying to validate the F2F_YOTI_PDF_LETTER_POSTED event immediately after making a call to documentSelection, now hitting all F2F endpoint up until userInfo giving enough time for the events we wish to validate to be stored in our Test Harness S3 bucket. 

### Why did it change

Was causing failures in the F2F dev pipelines. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2124](https://govukverify.atlassian.net/browse/KIWI-2124)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-2124]: https://govukverify.atlassian.net/browse/KIWI-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ