### PR TITLE
KIWI-2089: Moved dynamic value yoti base url out of the yoti service constructor

### DIFF
--- a/f2f-ipv-stub/src/handlers/startF2fCheck.ts
+++ b/f2f-ipv-stub/src/handlers/startF2fCheck.ts
@@ -61,7 +61,7 @@ export const handler = async (
         streetName: "Demo",
         addressLocality: "London",
         addressCountry: "GB",
-        postalCode: "SW19",
+        postalCode: "BA2 5AA",
       },
     ],
     emailAddress: "fred.flintstone@bedrock-live.com",

--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -161,7 +161,7 @@ export class DocumentSelectionRequestProcessor {
 			return Response(HttpCodesEnum.BAD_REQUEST, "Bad Request");
 		}
 
-		this.yotiService = YotiService.getInstance(this.logger, this.metrics, this.YOTI_PRIVATE_KEY, clientConfig.YotiBaseUrl);
+		this.yotiService = YotiService.getInstance(this.logger, this.metrics, this.YOTI_PRIVATE_KEY);
 
 		// Reject the request when session store does not contain email, familyName or GivenName fields
 		const data = this.validationHelper.isPersonDetailsValid(personDetails.emailAddress, personDetails.name);
@@ -175,6 +175,7 @@ export class DocumentSelectionRequestProcessor {
 			const PRINTED_CUSTOMER_LETTER_ENABLED = await getParameter(this.environmentVariables.printedCustomerLetterEnabledSsmPath());
 			try {
 				yotiSessionId = await this.createSessionGenerateInstructions(
+					clientConfig.YotiBaseUrl,
 					personDetails,
 					f2fSessionInfo,
 					postOfficeSelection,
@@ -319,6 +320,7 @@ export class DocumentSelectionRequestProcessor {
 	}
 
 	async createSessionGenerateInstructions(
+		yotiBaseUrl: string,
 		personDetails: PersonIdentityItem,
 		f2fSessionInfo: ISessionItem,
 		postOfficeSelection: PostOfficeInfo,
@@ -327,7 +329,7 @@ export class DocumentSelectionRequestProcessor {
 	): Promise<string> {
 		this.logger.info("Creating new session in Yoti for: ", { "sessionId": f2fSessionInfo.sessionId });
 
-		const yotiSessionId = await this.yotiService.createSession(personDetails, selectedDocument, countryCode, this.environmentVariables.yotiCallbackUrl());
+		const yotiSessionId = await this.yotiService.createSession(personDetails, selectedDocument, countryCode, yotiBaseUrl, this.environmentVariables.yotiCallbackUrl());
 		this.metrics.addMetric("DocSelect_yoti_session_created", MetricUnits.Count, 1);
 
 		if (!yotiSessionId) {
@@ -336,7 +338,7 @@ export class DocumentSelectionRequestProcessor {
 		}
 
 		this.logger.info("Fetching Session Info");
-		const yotiSessionInfo = await this.yotiService.fetchSessionInfo(yotiSessionId);
+		const yotiSessionInfo = await this.yotiService.fetchSessionInfo(yotiSessionId, yotiBaseUrl);
 
 		if (!yotiSessionInfo) {
 			this.logger.error("An error occurred when fetching Yoti Session", { messageCode: MessageCodes.FAILED_FETCHING_YOTI_SESSION });
@@ -379,6 +381,7 @@ export class DocumentSelectionRequestProcessor {
 			personDetails,
 			requirements,
 			postOfficeSelection,
+			yotiBaseUrl,
 		);
 
 		if (generateInstructionsResponse !== HttpCodesEnum.OK) {

--- a/src/services/GenerateYotiLetterProcessor.ts
+++ b/src/services/GenerateYotiLetterProcessor.ts
@@ -90,13 +90,13 @@ export class GenerateYotiLetterProcessor {
 			return Response(HttpCodesEnum.BAD_REQUEST, "Bad Request");
 		}
 
-		this.yotiService = YotiService.getInstance(this.logger, this.metrics, this.YOTI_PRIVATE_KEY, clientConfig.YotiBaseUrl);
+		this.yotiService = YotiService.getInstance(this.logger, this.metrics, this.YOTI_PRIVATE_KEY);
 
 		this.logger.info(
 			"Fetching the Instructions Pdf from yoti for sessionId: ",
 			f2fSessionInfo.yotiSessionId!,
 		);
-		const encoded = await this.yotiService.fetchInstructionsPdf(f2fSessionInfo.yotiSessionId!);
+		const encoded = await this.yotiService.fetchInstructionsPdf(f2fSessionInfo.yotiSessionId!, clientConfig.YotiBaseUrl);
 
 		if (!encoded) {
 			this.logger.error("An error occurred when generating Yoti instructions pdf", { messageCode: MessageCodes.FAILED_YOTI_PUT_INSTRUCTIONS });

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -413,10 +413,10 @@ export class SendEmailService {
   				this.logger,
   				this.metrics,
   				this.YOTI_PRIVATE_KEY,
-  				yotiBaseUrl,
   			);
   			const instructionsPdf = await this.yotiService.fetchInstructionsPdf(
   				message.yotiSessionId,
+  				yotiBaseUrl,
   			);
   			if (instructionsPdf) {
   				const encoded = Buffer.from(instructionsPdf, "binary").toString(

--- a/src/services/ThankYouEmailProcessor.ts
+++ b/src/services/ThankYouEmailProcessor.ts
@@ -95,10 +95,10 @@ export class ThankYouEmailProcessor {
 				return Response(HttpCodesEnum.BAD_REQUEST, "Bad Request");
 			}
 
-			this.yotiService = YotiService.getInstance(this.logger, this.metrics, this.YOTI_PRIVATE_KEY, clientConfig.YotiBaseUrl);
+			this.yotiService = YotiService.getInstance(this.logger, this.metrics, this.YOTI_PRIVATE_KEY);
 
   		this.logger.info({ message: "Fetching yoti session" });
-		  const yotiSessionInfo: YotiCompletedSession | undefined = await this.yotiService.getCompletedSessionInfo(yotiSessionID, this.environmentVariables.fetchYotiSessionBackoffPeriod(), this.environmentVariables.fetchYotiSessionMaxRetries());
+		  const yotiSessionInfo: YotiCompletedSession | undefined = await this.yotiService.getCompletedSessionInfo(yotiSessionID, this.environmentVariables.fetchYotiSessionBackoffPeriod(), this.environmentVariables.fetchYotiSessionMaxRetries(), clientConfig.YotiBaseUrl);
 
 		  if (!yotiSessionInfo) {
 			  this.logger.error({ message: "No Yoti Session found with ID" }, {

--- a/src/services/YotiSessionCompletionProcessor.ts
+++ b/src/services/YotiSessionCompletionProcessor.ts
@@ -125,12 +125,12 @@ export class YotiSessionCompletionProcessor {
 				return Response(HttpCodesEnum.BAD_REQUEST, "Bad Request");
 			}
 
-			this.yotiService = YotiService.getInstance(this.logger, this.metrics, this.YOTI_PRIVATE_KEY, clientConfig.YotiBaseUrl);
+			this.yotiService = YotiService.getInstance(this.logger, this.metrics, this.YOTI_PRIVATE_KEY);
 
 
 		  this.logger.info({ message: "Fetching status for Yoti SessionID" });
 		  // eslint-disable-next-line max-len
-		  const completedYotiSessionInfo = await this.yotiService.getCompletedSessionInfo(yotiSessionID, this.environmentVariables.fetchYotiSessionBackoffPeriod(), this.environmentVariables.fetchYotiSessionMaxRetries());
+		  const completedYotiSessionInfo = await this.yotiService.getCompletedSessionInfo(yotiSessionID, this.environmentVariables.fetchYotiSessionBackoffPeriod(), this.environmentVariables.fetchYotiSessionMaxRetries(), clientConfig.YotiBaseUrl);
 
 		  if (!completedYotiSessionInfo) {
 			  this.logger.error({ message: "No YOTI Session found with ID:" }, {
@@ -190,7 +190,7 @@ export class YotiSessionCompletionProcessor {
 			  throw new AppError(HttpCodesEnum.SERVER_ERROR, "Yoti document_fields media ID not found");
 		  }
 
-		  const documentFields = await this.yotiService.getMediaContent(yotiSessionID, documentFieldsId);
+		  const documentFields = await this.yotiService.getMediaContent(yotiSessionID, clientConfig.YotiBaseUrl, documentFieldsId);
 		  if (!documentFields) {
 			  this.logger.error({ message: "No document fields info found" }, {
 				  documentFieldsId,

--- a/src/tests/api/backend/HappyPath.test.ts
+++ b/src/tests/api/backend/HappyPath.test.ts
@@ -84,13 +84,16 @@ describe("/documentSelection Endpoint", () => {
 
 		await postDocumentSelection(docSelectionData, sessionId);
 
-		await getSessionAndVerifyKey(sessionId, constants.DEV_F2F_SESSION_TABLE_NAME, "authSessionState", "F2F_YOTI_SESSION_CREATED");
+		const session = await getSessionById(sessionId, constants.DEV_F2F_SESSION_TABLE_NAME);
+		expect(session?.authSessionState).toBe("F2F_YOTI_SESSION_CREATED");
 
 		const allTxmaEventBodies = await getTxmaEventsFromTestHarness(sessionId, 3);
 		validateTxMAEventData({ eventName: "F2F_CRI_START", schemaName: "F2F_CRI_START_SCHEMA" }, allTxmaEventBodies);
 		validateTxMAEventData({ eventName: "F2F_YOTI_START", schemaName: yotiStartSchema }, allTxmaEventBodies);
 		if (!constants.THIRD_PARTY_CLIENT_ID) {
 			validateTxMAEventData({ eventName: "F2F_YOTI_PDF_EMAILED", schemaName: "F2F_YOTI_PDF_EMAILED_SCHEMA" }, allTxmaEventBodies);
+			// eslint-disable-next-line jest/no-conditional-expect
+			expect(session?.yotiSessionId).toContain(yotiMockId);
 		}
 	});
 

--- a/src/tests/data/F2F_YOTI_PDF_LETTER_POSTED.json
+++ b/src/tests/data/F2F_YOTI_PDF_LETTER_POSTED.json
@@ -64,7 +64,6 @@
                 }
             },
             "required": [
-                "differentPostalAddress",
                 "evidence"
             ]
         },

--- a/src/tests/data/addressSessionPayload.json
+++ b/src/tests/data/addressSessionPayload.json
@@ -31,7 +31,7 @@
                 "streetName": "Demo",
                 "addressLocality": "London",
                 "addressCountry": "GB",
-                "postalCode": "SW19"
+                "postalCode": "BA2 5AA"
             }
         ],
         "emailAddress": "test@domain.com"

--- a/src/tests/data/exampleStubPayload.json
+++ b/src/tests/data/exampleStubPayload.json
@@ -34,7 +34,7 @@
                 "streetName": "Demo",
                 "addressLocality": "London",
                 "addressCountry": "GB",
-                "postalCode": "SW19"
+                "postalCode": "BA2 5AA"
             }
         ],
         "emailAddress": "test@domain.com"

--- a/src/tests/data/thinFilePayload.json
+++ b/src/tests/data/thinFilePayload.json
@@ -36,7 +36,7 @@
                 "streetName": "Demo",
                 "addressLocality": "London",
                 "addressCountry": "GB",
-                "postalCode": "SW19"
+                "postalCode": "BA2 5AA"
             }
         ],
         "emailAddress": "test@domain.com"

--- a/src/tests/unit/SendToGovNotifyHandler.test.ts
+++ b/src/tests/unit/SendToGovNotifyHandler.test.ts
@@ -32,7 +32,7 @@ const event = {
 		"buildingName": "London",
 		"streetName": "Demo",
 		"addressLocality": "London",
-		"postalCode": "SW19",
+		"postalCode": "BA2 5AA",
 		"addressCountry": "GB",
 		"preferredAddress": true,
 	},  

--- a/src/tests/unit/data/documentSelection-events.ts
+++ b/src/tests/unit/data/documentSelection-events.ts
@@ -305,7 +305,7 @@ export const MISSING_PREFERRED_ADDRESS = {
             	"streetName": "Demo",
             	"addressLocality": "London",
             	"addressCountry": "GB",
-            	"postalCode": "SW19",
+            	"postalCode": "BA2 5AA",
             },
 	}),
 };

--- a/src/tests/unit/services/YotiService.test.ts
+++ b/src/tests/unit/services/YotiService.test.ts
@@ -196,7 +196,6 @@ describe("YotiService", () => {
 			1209600,
 			10,
 			"PEM_KEY",
-			"YOTI_BASE_URL",
 		);
 	});
 
@@ -257,6 +256,7 @@ describe("YotiService", () => {
 	describe("createSession", () => {
 		const selectedDocument = "UKPASSPORT";
 		const YOTICALLBACKURL = "https://example.com/callback";
+		const YOTIBASEURL = "https://example.com/";
 
 		it("should create a Yoti session and return the session ID", async () => {
 			const generateYotiRequestMock = jest.spyOn(yotiService as any, "generateYotiRequest").mockReturnValue({
@@ -269,7 +269,7 @@ describe("YotiService", () => {
 			const fakeTime = 1684933200.123;
 			jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.123Z
 
-			const sessionId = await yotiService.createSession(personDetails, selectedDocument, "GBR", YOTICALLBACKURL);
+			const sessionId = await yotiService.createSession(personDetails, selectedDocument, "GBR", YOTIBASEURL, YOTICALLBACKURL);
 
 			expect(generateYotiRequestMock).toHaveBeenCalled();
 			expect(axios.post).toHaveBeenCalledWith("https://example.com/api/sessions", createSessionPayload, {});
@@ -289,7 +289,7 @@ describe("YotiService", () => {
 			const fakeTime = 1684933200.123;
 			jest.setSystemTime(new Date(fakeTime * 1000)); // 2023-05-24T13:00:00.123Z
 
-			await yotiService.createSession(personDetails, selectedDocument, "GBR", YOTICALLBACKURL);
+			await yotiService.createSession(personDetails, selectedDocument, "GBR", YOTIBASEURL, YOTICALLBACKURL);
 
 			expect(axios.post).toHaveBeenCalledWith("https://example.com/api/sessions", {
 				...createSessionPayload,
@@ -312,7 +312,7 @@ describe("YotiService", () => {
 				  data: { message: "failed to create session" },
 			  } });
 
-			await expect(yotiService.createSession(personDetails, selectedDocument, "GBR", YOTICALLBACKURL)).rejects.toThrow(
+			await expect(yotiService.createSession(personDetails, selectedDocument, "GBR", YOTIBASEURL, YOTICALLBACKURL)).rejects.toThrow(
 				new AppError(HttpCodesEnum.SERVER_ERROR, "Error creating Yoti Session"),
 			);
 
@@ -499,7 +499,7 @@ describe("YotiService", () => {
 
 			axiosMock.get.mockResolvedValueOnce({ status:201, data: expectedResponse });
 
-			const sessionInfo = await yotiService.fetchSessionInfo(sessionId);
+			const sessionInfo = await yotiService.fetchSessionInfo(sessionId, "http://localhost");
 
 			expect(generateYotiRequestMock).toHaveBeenCalled();
 			expect(axios.get).toHaveBeenCalledWith("https://example.com/api/sessions/session123/configuration", {});
@@ -521,7 +521,7 @@ describe("YotiService", () => {
 				"response": errorResponseHeaders,						
 			});
 
-			await expect(yotiService.fetchSessionInfo(sessionId)).rejects.toThrow();
+			await expect(yotiService.fetchSessionInfo(sessionId, "http://localhost")).rejects.toThrow();
 
 			expect(logger.error).toHaveBeenCalledWith(
 				{ "message": "Error fetching Yoti session", "yotiErrorCode": 404, "yotiErrorMessage": "Failed to fetch session info", "xRequestId": "dummy-request-id" },
@@ -563,7 +563,7 @@ describe("YotiService", () => {
 
 			axiosMock.put.mockResolvedValueOnce({ status: 200 });
 
-			const statusCode = await yotiService.generateInstructions(sessionID, personDetails, requirements, PostOfficeSelection);
+			const statusCode = await yotiService.generateInstructions(sessionID, personDetails, requirements, PostOfficeSelection, "http://localhost");
 
 			expect(generateYotiRequestMock).toHaveBeenCalled();
 			expect(axios.put).toHaveBeenCalledWith(
@@ -590,7 +590,7 @@ describe("YotiService", () => {
 			});
 
 			await expect(
-				yotiService.generateInstructions(sessionID, personDetails, requirements, PostOfficeSelection),
+				yotiService.generateInstructions(sessionID, personDetails, requirements, PostOfficeSelection, "http://localhost"),
 			).rejects.toThrow();
 
 			expect(logger.error).toHaveBeenCalledWith(
@@ -622,7 +622,7 @@ describe("YotiService", () => {
 			const pdfData = "mocked-pdf-data";
 			axiosMock.get.mockResolvedValueOnce({ status:200, data: pdfData });
 
-			const fetchedPdf = await yotiService.fetchInstructionsPdf(sessionId);
+			const fetchedPdf = await yotiService.fetchInstructionsPdf(sessionId, "http://localhost");
 
 			expect(generateYotiRequestMock).toHaveBeenCalled();
 			expect(axios.get).toHaveBeenCalledWith(
@@ -650,7 +650,7 @@ describe("YotiService", () => {
 				"response": errorResponseHeaders,						
 			});
 
-			await expect(yotiService.fetchInstructionsPdf(sessionId)).rejects.toThrow();
+			await expect(yotiService.fetchInstructionsPdf(sessionId, "http://localhost")).rejects.toThrow();
 
 			expect(logger.error).toHaveBeenCalledWith(
 				{ "message": "An error occurred when fetching Yoti instructions PDF", "messageCode": "FAILED_YOTI_GET_INSTRUCTIONS", "yotiErrorCode": 500, "yotiErrorMessage": "Failed to fetch PDF", "xRequestId": "dummy-request-id" },
@@ -676,7 +676,7 @@ describe("YotiService", () => {
 
 			axiosMock.get.mockResolvedValueOnce({ status:200, data: {} });
 
-			const completedSessionInfo = await yotiService.getCompletedSessionInfo(sessionId, 2000, 3);
+			const completedSessionInfo = await yotiService.getCompletedSessionInfo(sessionId, 2000, 3, "http://localhost");
 
 			expect(generateYotiRequestMock).toHaveBeenCalled();
 			expect(axios.get).toHaveBeenCalledWith("https://example.com/api/sessions/session123", {});
@@ -700,7 +700,7 @@ describe("YotiService", () => {
 					...errorResponseHeaders,
 				},
 			});
-			await expect(yotiService.getCompletedSessionInfo(sessionId, 2000, 3)).rejects.toThrow();
+			await expect(yotiService.getCompletedSessionInfo(sessionId, 2000, 3, "http://localhost")).rejects.toThrow();
 
 			expect(logger.error).toHaveBeenCalledWith(
 				{ "message": "An error occurred when fetching Yoti session", "messageCode": "FAILED_YOTI_GET_SESSION", "yotiErrorCode": 404, "yotiErrorMessage": "Failed to fetch completed session info", "xRequestId": "dummy-request-id" },
@@ -727,7 +727,7 @@ describe("YotiService", () => {
 				},
 			});
 
-			await expect(yotiService.getCompletedSessionInfo(sessionId, 2000, 3)).rejects.toThrow();
+			await expect(yotiService.getCompletedSessionInfo(sessionId, 2000, 3, "http://localhost")).rejects.toThrow();
 
 			expect(logger.error).toHaveBeenCalledWith(
 				{ "message": "An error occurred when fetching Yoti session", "messageCode": "FAILED_YOTI_GET_SESSION", "yotiErrorCode": 404, "yotiErrorMessage": "Failed to fetch completed session info", "xRequestId": "dummy-request-id" },
@@ -758,7 +758,7 @@ describe("YotiService", () => {
 				},
 			});
 
-			await expect(yotiService.getCompletedSessionInfo(sessionId, 2000, 3)).rejects.toThrow();
+			await expect(yotiService.getCompletedSessionInfo(sessionId, 2000, 3, "http://localhost")).rejects.toThrow();
 
 			expect(logger.warn).toHaveBeenCalledTimes(3);
 			expect(logger.warn).toHaveBeenNthCalledWith(2,
@@ -789,7 +789,7 @@ describe("YotiService", () => {
 			const responseData = null;
 			axiosMock.get.mockResolvedValueOnce({ data: responseData });
 
-			const result = await yotiService.getMediaContent(sessionId, mediaId);
+			const result = await yotiService.getMediaContent(sessionId, mediaId, "http://localhost");
 
 			expect(generateYotiRequestMock).toHaveBeenCalled();
 			expect(axios.get).toHaveBeenCalledWith(
@@ -812,7 +812,7 @@ describe("YotiService", () => {
 				"response": errorResponseHeaders,						
 			});	
 
-			await expect(yotiService.getMediaContent(sessionId, mediaId)).rejects.toThrow();
+			await expect(yotiService.getMediaContent(sessionId, mediaId, "http://localhost")).rejects.toThrow();
 
 			expect(axios.get).toHaveBeenCalledWith(
 				yotiRequest.url,


### PR DESCRIPTION
## Proposed changes

### What changed

Moved Yoti base url from constructor into method parameters so it can be updated as part of test data strategy

### Why did it change

To allow multiple tests to be run together as part of canaries

