### PR TITLE
KIWI-2170: Third-Party Test Update - Remove yotiMockId

### DIFF
--- a/src/tests/api/ApiTestSteps.ts
+++ b/src/tests/api/ApiTestSteps.ts
@@ -61,6 +61,7 @@ export async function stubStartPost(stubPayload: StubStartRequest): Promise<Axio
 	const path = constants.DEV_IPV_F2F_STUB_URL;
 	if (constants.THIRD_PARTY_CLIENT_ID) {
 		stubPayload.clientId = constants.THIRD_PARTY_CLIENT_ID;
+		delete stubPayload.yotiMockID;
 	}
 	try {
 		const postRequest = await axios.post(`${path}`, stubPayload);

--- a/src/tests/api/types.ts
+++ b/src/tests/api/types.ts
@@ -45,7 +45,7 @@ export interface PostalAddress {
 
 export interface StubStartRequest {
 	clientId?: string;
-	yotiMockID: string;
+	yotiMockID?: string;
 	shared_claims: {
 		name: Name[];
 		birthDate: BirthDate[];


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e8f644f9-4c47-49c8-85c7-c3d2032aa0cd)

## Proposed changes

### What changed

Remove yotiMockId from shared_claims for third-party API tests


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2170](https://govukverify.atlassian.net/browse/KIWI-2170)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[KIWI-2170]: https://govukverify.atlassian.net/browse/KIWI-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ