### PR TITLE
[KIWI-2188-clean] Adding Metrics for Observability to a new dynatrace dashboard

### DIFF
--- a/src/services/AddressLocationsProcessor.ts
+++ b/src/services/AddressLocationsProcessor.ts
@@ -30,7 +30,7 @@ export class AddressLocationsProcessor {
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.ADDRESS_LOCATIONS_SERVICE);
 		this.logger = logger;
   		this.metrics = metrics;
-  		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient(), this.metrics);
 	}
 
 	static getInstance(logger: Logger, metrics: Metrics, osApiKey: string): AddressLocationsProcessor {

--- a/src/services/DocumentSelectionRequestProcessor.ts
+++ b/src/services/DocumentSelectionRequestProcessor.ts
@@ -181,6 +181,7 @@ export class DocumentSelectionRequestProcessor {
 						const singleMetric = this.metrics.singleMetric();
 						singleMetric.addDimension("pdf_preference", pdfPreference);
 						singleMetric.addMetric("DocSelect_comms_choice", MetricUnits.Count, 1);
+						singleMetric.addMetric("F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 						await this.startStateMachine(sessionId, yotiSessionId, f2fSessionInfo?.clientSessionId, pdfPreference);
 					} else {
 						await this.postToGovNotify(f2fSessionInfo.sessionId, yotiSessionId, personDetails);

--- a/src/services/GeneratePrintedLetterProcessor.ts
+++ b/src/services/GeneratePrintedLetterProcessor.ts
@@ -34,7 +34,7 @@ export class GeneratePrintedLetterProcessor {
 		this.logger = logger;
 		this.metrics = metrics;
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.GENERATE_PRINTED_LETTER_SERVICE);
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient(), this.metrics);
 		this.pdfService = PDFService.getInstance(logger, metrics);
 		this.s3Client = new S3Client({
 			region: process.env.REGION,

--- a/src/services/GenerateYotiLetterProcessor.ts
+++ b/src/services/GenerateYotiLetterProcessor.ts
@@ -39,7 +39,7 @@ export class GenerateYotiLetterProcessor {
 		this.logger = logger;
 		this.metrics = metrics;
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.GENERATE_YOTI_LETTER_SERVICE);
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient(), this.metrics);
 		this.validationHelper = new ValidationHelper();
 		this.YOTI_PRIVATE_KEY = YOTI_PRIVATE_KEY;
 		this.s3Client = new S3Client({

--- a/src/services/PdfService.ts
+++ b/src/services/PdfService.ts
@@ -17,7 +17,7 @@ export class PDFService {
   private constructor(logger: Logger, metrics: Metrics) {
   	this.logger = logger;
   	this.metrics = metrics;
-  	this.pdfGenerationService = PDFGenerationService.getInstance(this.logger);
+  	this.pdfGenerationService = PDFGenerationService.getInstance(this.logger, this.metrics);
 	
   }
 

--- a/src/services/PersonInfoRequestProcessor.ts
+++ b/src/services/PersonInfoRequestProcessor.ts
@@ -29,7 +29,7 @@ export class PersonInfoRequestProcessor {
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.PERSON_INFO_SERVICE);
 		this.logger = logger;
   		this.metrics = metrics;
-  		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient(), this.metrics);
 	}
 
 	static getInstance(logger: Logger, metrics: Metrics, publicKey: string): PersonInfoRequestProcessor {

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -78,6 +78,7 @@ export class SendEmailService {
   		this.environmentVariables.sessionTable(),
   		this.logger,
   		createDynamoDbClient(),
+  		this.metrics,
   	);
   	this.YOTI_PRIVATE_KEY = YOTI_PRIVATE_KEY;
   	this.validationHelper = new ValidationHelper();
@@ -234,14 +235,14 @@ export class SendEmailService {
 
   		const formattedDate = this.formatExpiryDate(sessionConfigObject.f2fSessionInfo);
 
-  	
+  
   		const options = {
   			personalisation: {
   				[GOV_NOTIFY_OPTIONS.FIRST_NAME]: message.firstName,
   				[GOV_NOTIFY_OPTIONS.LAST_NAME]: message.lastName,
   				[GOV_NOTIFY_OPTIONS.DATE]: formattedDate,
   				[GOV_NOTIFY_OPTIONS.CHOSEN_PHOTO_ID]: message.documentUsed,
-				  [GOV_NOTIFY_OPTIONS.LINK_TO_FILE]: {
+  				  [GOV_NOTIFY_OPTIONS.LINK_TO_FILE]: {
   					file: encoded,
   					confirm_email_before_download: true,
   					retention_period: "2 weeks",

--- a/src/services/SendToGovNotifyService.ts
+++ b/src/services/SendToGovNotifyService.ts
@@ -73,6 +73,7 @@ export class SendToGovNotifyService {
   		this.environmentVariables.sessionTable(),
   		this.logger,
   		createDynamoDbClient(),
+  		metrics,
   	);
 	  this.s3Client = new S3Client({
   		region: process.env.REGION,

--- a/src/services/SessionConfigRequestProcessor.ts
+++ b/src/services/SessionConfigRequestProcessor.ts
@@ -31,7 +31,7 @@ export class SessionConfigRequestProcessor {
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.SESSION_CONFIG_SERVICE);
 		this.validationHelper = new ValidationHelper();
 		this.metrics = metrics;
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient(), this.metrics);
 	}
 
 	static getInstance(logger: Logger, metrics: Metrics): SessionConfigRequestProcessor {

--- a/src/tests/unit/services/PdfGenerationService.test.ts
+++ b/src/tests/unit/services/PdfGenerationService.test.ts
@@ -3,6 +3,7 @@
 import fs from "fs";
 
 import { Logger } from "@aws-lambda-powertools/logger";
+import { Metrics } from "@aws-lambda-powertools/metrics";
 import { mock } from "jest-mock-extended";
 
 import { PersonIdentityAddress, PersonIdentityItem } from "../../../models/PersonIdentityItem";
@@ -11,6 +12,7 @@ import { PDFGenerationService } from "../../../services/pdfGenerationService";
 
 let pdfGenerationService: PDFGenerationService;
 const mockF2fService = mock<F2fService>();
+const metrics = mock<Metrics>();
 
 const logger = mock<Logger>();
 const sessionId = "sessionId";
@@ -62,7 +64,7 @@ const person: PersonIdentityItem = {
 
 describe("PdfGenerationServiceTest", () => {
 	beforeAll(() => {
-		pdfGenerationService = PDFGenerationService.getInstance(logger);
+		pdfGenerationService = PDFGenerationService.getInstance(logger, metrics);
 		// @ts-ignore
 		pdfGenerationService.f2fService = mockF2fService;
 	});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
`[KIWI-2188] Adding Metrics for Observability to a new dynatrace dashboard`

## Proposed changes

### What changed

This PR introduces new metrics to improve observability in the F2F (Face to Face) journey. The changes include:

1. **Session Metrics**:
   - Added `session_created` metric to track successful session creation in `sessionRequestProcessor`.
   - Added `GovNotify_PDF_email_sent` metric to track confirmation emails sent in `sendEmailProcessor`.
   - Added `DocSelect_pdf_email_added_to_queue` metric in `documentSelectionRequestProcessor`.
   - Added `DocSelect_comms_choice` metric with `pdf_preference` dimension to track user communication preferences.
   - Added `F2F_YOTI_SESSION_CREATED` metric to track Yoti session creation.
   - Enhanced `GovNotify_email_sent` metric to include `emailType` dimension (Pdf, reminder, dynamic_reminder).

2. **User Info Metrics**:
   - Added `UserInfo_pending_VC_returned` metric to track pending VC retrieval in `userInfoRequestProcessor`.

3. **Document Upload Metrics**:
   - Added `document_uploaded_at_PO` metric to track document uploads at the Post Office in `ThankYouEmailProcessor`.

4. **Yoti Session Metrics**:
   - Added `SessionCompletion_yoti_response_parsed` metric to track Yoti document checks in `YotiSessionCompletionProcessor`.
   - Added `SessionCompletion_VC_issued_successfully` metric to track successful VC issuance.

5. **State Transition Metrics**:
   - Added metrics for state transitions: 
     - `F2F_SESSION_CREATED`
     - `F2F_YOTI_SESSION_CREATED`
     - `F2F_AUTH_CODE_ISSUED`
     - `F2F_ACCESS_TOKEN_ISSUED`
     - `F2F_YOTI_SESSION_COMPLETE`
     - `F2F_CREDENTIAL_ISSUED`
     - `F2F_SESSION_ABORTED`
     - `F2F_CRI_SESSION_ABORTED`
     - `F2F_SESSION_EXPIRED`

### Why did it change

These changes were made to improve observability in the F2F journey. By adding these metrics, we can now track and visualise:
- How many users begin the F2F journey.
- How many users complete each step of the journey.
- The success rates of key processes (e.g., session creation, document upload, VC issuance).
- State transitions throughout the F2F flow.
- User communication preferences (email vs. printed letter).

This will help identify bottlenecks, monitor performance, and ensure a smoother user experience.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2188](https://govukverify.atlassian.net/browse/KIWI-2188)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[KIWI-2188]: https://govukverify.atlassian.net/browse/KIWI-2188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
