### PR TITLE
KIWI-2188: Added metrics to track the flow of users through the F2F journery

### DIFF
--- a/src/services/AbortRequestProcessor.ts
+++ b/src/services/AbortRequestProcessor.ts
@@ -1,6 +1,6 @@
 import { Response } from "../utils/Response";
 import { F2fService } from "./F2fService";
-import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { AppError } from "../utils/AppError";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { HttpCodesEnum } from "../utils/HttpCodesEnum";
@@ -29,7 +29,7 @@ export class AbortRequestProcessor {
   	this.logger = logger;
   	this.metrics = metrics;
   	this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.ABORT_SERVICE);
-  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
   }
 
   static getInstance(
@@ -67,6 +67,8 @@ export class AbortRequestProcessor {
 
   	try {
   	  await this.f2fService.updateSessionAuthState(f2fSessionInfo.sessionId, AuthSessionState.F2F_CRI_SESSION_ABORTED);
+	  this.metrics.addMetric("state-F2F_CRI_SESSION_ABORTED", MetricUnits.Count, 1);
+
   	} catch (error) {
   		this.logger.error("Error occurred while aborting the session", {
   			error,

--- a/src/services/AccessTokenRequestProcessor.ts
+++ b/src/services/AccessTokenRequestProcessor.ts
@@ -37,7 +37,7 @@ export class AccessTokenRequestProcessor {
 		this.kmsJwtAdapter = new KmsJwtAdapter(this.environmentVariables.kmsKeyArn());
 		this.accessTokenRequestValidationHelper = new AccessTokenRequestValidationHelper();
 		this.metrics = metrics;
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 	}
 
 	static getInstance(logger: Logger, metrics: Metrics): AccessTokenRequestProcessor {

--- a/src/services/AddressLocationsProcessor.ts
+++ b/src/services/AddressLocationsProcessor.ts
@@ -30,7 +30,7 @@ export class AddressLocationsProcessor {
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.ADDRESS_LOCATIONS_SERVICE);
 		this.logger = logger;
   		this.metrics = metrics;
-  		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 	}
 
 	static getInstance(logger: Logger, metrics: Metrics, osApiKey: string): AddressLocationsProcessor {

--- a/src/services/AuthorizationRequestProcessor.ts
+++ b/src/services/AuthorizationRequestProcessor.ts
@@ -29,7 +29,7 @@ export class AuthorizationRequestProcessor {
 		this.logger = logger;
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.AUTHORIZATION_SERVICE);
 		this.metrics = metrics;
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 	}
 
 	static getInstance(logger: Logger, metrics: Metrics): AuthorizationRequestProcessor {

--- a/src/services/ExpiredSessionsProcessor.ts
+++ b/src/services/ExpiredSessionsProcessor.ts
@@ -19,7 +19,7 @@ export class ExpiredSessionsProcessor {
 
   constructor(private readonly logger: Logger, private readonly metrics: Metrics) {
   	const envVariables = new EnvironmentVariables(logger, ServicesEnum.REMINDER_SERVICE);
-  	this.f2fService = F2fService.getInstance(envVariables.sessionTable(), logger, createDynamoDbClient());
+  	this.f2fService = F2fService.getInstance(envVariables.sessionTable(), logger, metrics, createDynamoDbClient());
   }
 
   static getInstance(logger: Logger, metrics: Metrics): ExpiredSessionsProcessor {

--- a/src/services/GeneratePrintedLetterProcessor.ts
+++ b/src/services/GeneratePrintedLetterProcessor.ts
@@ -34,7 +34,7 @@ export class GeneratePrintedLetterProcessor {
 		this.logger = logger;
 		this.metrics = metrics;
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.GENERATE_PRINTED_LETTER_SERVICE);
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 		this.pdfService = PDFService.getInstance(logger, metrics);
 		this.s3Client = new S3Client({
 			region: process.env.REGION,

--- a/src/services/GenerateYotiLetterProcessor.ts
+++ b/src/services/GenerateYotiLetterProcessor.ts
@@ -39,7 +39,7 @@ export class GenerateYotiLetterProcessor {
 		this.logger = logger;
 		this.metrics = metrics;
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.GENERATE_YOTI_LETTER_SERVICE);
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 		this.validationHelper = new ValidationHelper();
 		this.YOTI_PRIVATE_KEY = YOTI_PRIVATE_KEY;
 		this.s3Client = new S3Client({

--- a/src/services/PdfService.ts
+++ b/src/services/PdfService.ts
@@ -17,7 +17,7 @@ export class PDFService {
   private constructor(logger: Logger, metrics: Metrics) {
   	this.logger = logger;
   	this.metrics = metrics;
-  	this.pdfGenerationService = PDFGenerationService.getInstance(this.logger);
+  	this.pdfGenerationService = PDFGenerationService.getInstance(this.logger, this.metrics);
 	
   }
 

--- a/src/services/PersonInfoRequestProcessor.ts
+++ b/src/services/PersonInfoRequestProcessor.ts
@@ -29,7 +29,7 @@ export class PersonInfoRequestProcessor {
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.PERSON_INFO_SERVICE);
 		this.logger = logger;
   		this.metrics = metrics;
-  		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 	}
 
 	static getInstance(logger: Logger, metrics: Metrics, publicKey: string): PersonInfoRequestProcessor {

--- a/src/services/ReminderEmailProcessor.ts
+++ b/src/services/ReminderEmailProcessor.ts
@@ -21,7 +21,7 @@ export class ReminderEmailProcessor {
 
   constructor(private readonly logger: Logger, private readonly metrics: Metrics) {
   	const envVariables = new EnvironmentVariables(logger, ServicesEnum.REMINDER_SERVICE);
-  	this.f2fService = F2fService.getInstance(envVariables.sessionTable(), logger, createDynamoDbClient());
+  	this.f2fService = F2fService.getInstance(envVariables.sessionTable(), logger, metrics, createDynamoDbClient());
   }
 
   static getInstance(logger: Logger, metrics: Metrics): ReminderEmailProcessor {

--- a/src/services/SendEmailService.ts
+++ b/src/services/SendEmailService.ts
@@ -77,6 +77,7 @@ export class SendEmailService {
   	this.f2fService = F2fService.getInstance(
   		this.environmentVariables.sessionTable(),
   		this.logger,
+		this.metrics,
   		createDynamoDbClient(),
   	);
   	this.YOTI_PRIVATE_KEY = YOTI_PRIVATE_KEY;

--- a/src/services/SendToGovNotifyService.ts
+++ b/src/services/SendToGovNotifyService.ts
@@ -72,6 +72,7 @@ export class SendToGovNotifyService {
   	this.f2fService = F2fService.getInstance(
   		this.environmentVariables.sessionTable(),
   		this.logger,
+		this.metrics,
   		createDynamoDbClient(),
   	);
 	  this.s3Client = new S3Client({

--- a/src/services/SessionConfigRequestProcessor.ts
+++ b/src/services/SessionConfigRequestProcessor.ts
@@ -31,7 +31,7 @@ export class SessionConfigRequestProcessor {
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.SESSION_CONFIG_SERVICE);
 		this.validationHelper = new ValidationHelper();
 		this.metrics = metrics;
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 	}
 
 	static getInstance(logger: Logger, metrics: Metrics): SessionConfigRequestProcessor {

--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -47,7 +47,7 @@ export class SessionRequestProcessor {
   	this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.SESSION_SERVICE);
   	logger.debug("metrics is  " + JSON.stringify(this.metrics));
   	this.metrics.addMetric("Called", MetricUnits.Count, 1);
-  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
   	this.kmsDecryptor = new KmsJwtAdapter(this.environmentVariables.encryptionKeyIds());
   	this.validationHelper = new ValidationHelper();
   }
@@ -199,6 +199,7 @@ export class SessionRequestProcessor {
 
   	try {
   		await this.f2fService.createAuthSession(session);
+		this.metrics.addMetric("state-F2F_SESSION_CREATED", MetricUnits.Count, 1);
   	} catch (error) {
   		this.logger.error("Failed to create session in session table", {
   			error,
@@ -240,6 +241,8 @@ export class SessionRequestProcessor {
   	}
 
   	this.logger.info("Session created successfully. Returning 200OK");
+
+	this.metrics.addMetric("session_created", MetricUnits.Count, 1);
 
   	return {
   		statusCode: HttpCodesEnum.OK,

--- a/src/services/ThankYouEmailProcessor.ts
+++ b/src/services/ThankYouEmailProcessor.ts
@@ -1,5 +1,5 @@
 import { F2fService } from "./F2fService";
-import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { EnvironmentVariables } from "./EnvironmentVariables";
 import { MessageCodes } from "../models/enums/MessageCodes";
@@ -44,7 +44,7 @@ export class ThankYouEmailProcessor {
   	this.logger = logger;
   	this.metrics = metrics;
   	this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.THANK_YOU_EMAIL_SERVICE);
-  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 		this.YOTI_PRIVATE_KEY = YOTI_PRIVATE_KEY;
 		this.validationHelper = new ValidationHelper();
 	}
@@ -132,6 +132,7 @@ export class ThankYouEmailProcessor {
   			},
   		});
 
+		this.metrics.addMetric("document_uploaded_at_PO", MetricUnits.Count, 1);
   		return Response(HttpCodesEnum.OK, "OK");
 
   	} else {

--- a/src/services/UserInfoRequestProcessor.ts
+++ b/src/services/UserInfoRequestProcessor.ts
@@ -34,7 +34,7 @@ export class UserInfoRequestProcessor {
 		this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.USERINFO_SERVICE);
 		this.validationHelper = new ValidationHelper();
 		this.metrics = metrics;
-		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+		this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
 		this.kmsJwtAdapter = new KmsJwtAdapter(this.environmentVariables.kmsKeyArn());
 	}
 
@@ -78,6 +78,8 @@ export class UserInfoRequestProcessor {
     	// Validate the AuthSessionState to be "F2F_ACCESS_TOKEN_ISSUED"
     	if (session.authSessionState === AuthSessionState.F2F_ACCESS_TOKEN_ISSUED) {
 			this.logger.info("Returning success response");
+			this.metrics.addMetric("UserInfo_pending_VC_returned", MetricUnits.Count, 1);
+
 			return Response(HttpCodesEnum.ACCEPTED, JSON.stringify({
 				sub: session.subject,
 				"https://vocab.account.gov.uk/v1/credentialStatus": "pending",

--- a/src/services/YotiSessionCompletionProcessor.ts
+++ b/src/services/YotiSessionCompletionProcessor.ts
@@ -1,6 +1,6 @@
 import { Response } from "../utils/Response";
 import { F2fService } from "./F2fService";
-import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { AppError } from "../utils/AppError";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { YotiService } from "./YotiService";
@@ -59,7 +59,7 @@ export class YotiSessionCompletionProcessor {
   	this.logger = logger;
   	this.metrics = metrics;
   	this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.CALLBACK_SERVICE);
-  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
   	this.kmsJwtAdapter = new KmsJwtAdapter(this.environmentVariables.kmsKeyArn());
   	this.verifiableCredentialService = VerifiableCredentialService.getInstance(this.environmentVariables.sessionTable(), this.kmsJwtAdapter, this.environmentVariables.issuer(), this.logger, this.environmentVariables.dnsSuffix());
   	this.generateVerifiableCredential = GenerateVerifiableCredential.getInstance(this.logger);
@@ -230,7 +230,9 @@ export class YotiSessionCompletionProcessor {
 					  messageCode: MessageCodes.FAILED_TO_WRITE_TXMA,
 				  });
 			  }
-				
+			
+			this.metrics.addMetric("SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+
   			const { given_names, family_name, full_name } = documentFields;
 
   			const missingGivenName = this.checkMissingField(given_names, "given_names");
@@ -324,6 +326,8 @@ export class YotiSessionCompletionProcessor {
 				  AuthSessionState.F2F_CREDENTIAL_ISSUED,
 			  );
 
+			  this.metrics.addMetric("state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+			  this.metrics.addMetric("SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 			  return Response(HttpCodesEnum.OK, "OK");
 		  } else {
 			  this.logger.error({ message: "AuthSession is in wrong Auth state", sessionState: f2fSession.authSessionState });

--- a/src/services/pdfGenerationService.ts
+++ b/src/services/pdfGenerationService.ts
@@ -14,6 +14,7 @@ import govUkLogo from "../static/govuk-logo-lockup-black-1800px.png";
 
 import { PersonIdentityAddress } from "../models/PersonIdentityItem";
 import { personIdentityUtils } from "../utils/PersonIdentityUtils";
+import { Metrics } from "@aws-lambda-powertools/metrics";
 
 export class PDFGenerationService {
 
@@ -25,20 +26,24 @@ export class PDFGenerationService {
 
   private readonly logger: Logger;
 
-  private constructor(logger: Logger) {
+  private readonly metrics: Metrics;
+
+  private constructor(logger: Logger, metrics: Metrics) {
   	this.logger = logger;
+	this.metrics = metrics;
   	this.environmentVariables = new EnvironmentVariables(logger, ServicesEnum.GENERATE_PRINTED_LETTER_SERVICE);
-  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, createDynamoDbClient());
+  	this.f2fService = F2fService.getInstance(this.environmentVariables.sessionTable(), this.logger, this.metrics, createDynamoDbClient());
   }
 
 mmToPt = (mm: number) => mm * 2.83465;
 
 static getInstance(
 	logger: Logger,
+	metrics: Metrics
 ): PDFGenerationService {
 	if (!PDFGenerationService.instance) {
 		PDFGenerationService.instance = new PDFGenerationService(
-			logger,
+			logger, metrics
 		);
 	}
 	return PDFGenerationService.instance;

--- a/src/tests/unit/services/AbortRequestProcessor.test.ts
+++ b/src/tests/unit/services/AbortRequestProcessor.test.ts
@@ -1,5 +1,5 @@
 import { mock } from "jest-mock-extended";
-import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { AbortRequestProcessor } from "../../../services/AbortRequestProcessor";
 import { F2fService } from "../../../services/F2fService";
@@ -15,7 +15,7 @@ const logger = mock<Logger>();
 
 let abortRequestProcessor: AbortRequestProcessor;
 let f2fSessionItem: ISessionItem;
-const metrics = new Metrics({ namespace: "F2F" });
+const metrics = mock<Metrics>();
 const sessionId = "RandomF2FSessionID";
 const encodedHeader = "ENCHEADER";
 function getMockSessionItem(): ISessionItem {
@@ -75,6 +75,7 @@ describe("AbortRequestProcessor", () => {
 		expect(out.body).toBe("Session has already been aborted");
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		expect(logger.info).toHaveBeenCalledWith("Session has already been aborted");
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("updates auth session state and returns successful response if session has not been aborted", async () => {
@@ -87,6 +88,7 @@ describe("AbortRequestProcessor", () => {
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("Session has been aborted");
 		expect(out.headers?.Location).toBe(encodeURIComponent(`${f2fSessionItem.redirectUri}?error=access_denied&state=${f2fSessionItem.state}`));
+		expect(metrics.addMetric).toHaveBeenCalledWith("state-F2F_CRI_SESSION_ABORTED", MetricUnits.Count, 1)
 	});
 
 	it("Returns successful response if session has not been aborted and redirectUri contains f2f id", async () => {
@@ -101,6 +103,7 @@ describe("AbortRequestProcessor", () => {
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("Session has been aborted");
 		expect(out.headers?.Location).toContain(encodeURIComponent(`${f2fSessionItem.redirectUri}&error=access_denied&state=${f2fSessionItem.state}`));
+		expect(metrics.addMetric).toHaveBeenCalledWith("state-F2F_CRI_SESSION_ABORTED", MetricUnits.Count, 1)
 	});
 
 	it("sends TxMA event after auth session state has been updated", async () => {
@@ -112,6 +115,7 @@ describe("AbortRequestProcessor", () => {
 		expect(mockF2fService.sendToTXMA).toHaveBeenCalledWith(expect.objectContaining({
 			event_name: TxmaEventNames.F2F_CRI_SESSION_ABORTED,
 		}), encodedHeader);
+		expect(metrics.addMetric).toHaveBeenCalledWith("state-F2F_CRI_SESSION_ABORTED", MetricUnits.Count, 1)
 	});
 
 	it("logs error if sending TxMA event fails, but successful response is still returned", async () => {
@@ -127,6 +131,7 @@ describe("AbortRequestProcessor", () => {
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("Session has been aborted");
+		expect(metrics.addMetric).toHaveBeenCalledWith("state-F2F_CRI_SESSION_ABORTED", MetricUnits.Count, 1)
 	});
 
 	it("returns failed response if auth session state cannot be updated", async () => {
@@ -137,5 +142,6 @@ describe("AbortRequestProcessor", () => {
 
 		expect(out.statusCode).toBe(HttpCodesEnum.SERVER_ERROR);
 		expect(out.body).toBe("An error has occurred");
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 });

--- a/src/tests/unit/services/DocumentSelectionRequestProcessor.test.ts
+++ b/src/tests/unit/services/DocumentSelectionRequestProcessor.test.ts
@@ -244,6 +244,8 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(mockF2fService.updateSessionWithYotiIdAndStatus).toHaveBeenCalledWith("RandomF2FSessionID", "b83d54ce-1565-42ee-987a-97a1f48f27dg", "F2F_YOTI_SESSION_CREATED");
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("Instructions PDF Generated");
+		expect(metrics.addMetric).toHaveBeenCalledWith("DocSelect_pdf_email_added_to_queue", MetricUnits.Count, 1)
+		expect(metrics.addMetric).toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1)
 	});
 
 	it("Should return successful response with 200 OK when non-UK passport used for YOTI session", async () => {
@@ -269,6 +271,8 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(mockF2fService.updateSessionWithYotiIdAndStatus).toHaveBeenCalledWith("RandomF2FSessionID", "b83d54ce-1565-42ee-987a-97a1f48f27dg", "F2F_YOTI_SESSION_CREATED");
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("Instructions PDF Generated");
+		expect(metrics.addMetric).toHaveBeenCalledWith("DocSelect_pdf_email_added_to_queue", MetricUnits.Count, 1)
+		expect(metrics.addMetric).toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1)
 	});
 
 	it("Should return successful response with 200 OK when an EEA ID Card is used and creates YOTI session", async () => {
@@ -297,6 +301,8 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(mockF2fService.updateSessionWithYotiIdAndStatus).toHaveBeenCalledWith("RandomF2FSessionID", "b83d54ce-1565-42ee-987a-97a1f48f27dg", "F2F_YOTI_SESSION_CREATED");
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("Instructions PDF Generated");
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "DocSelect_pdf_email_added_to_queue", MetricUnits.Count, 1)
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1)
 	});
 
 	it("Throws bad request error when personDetails is missing", async () => {
@@ -310,6 +316,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.warn).toHaveBeenNthCalledWith(1,
 			"Missing details in SESSION or PERSON IDENTITY tables", { "messageCode": "SESSION_NOT_FOUND" },
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("Returns bad request response when pdf_preference is missing from FE payload", async () => {
@@ -322,6 +329,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		);
 		expect(metrics.addDimension).toHaveBeenCalledWith("validation_failure", "missingPdfPreference");
 		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "DocSelect_validation_failed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).not.toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it.each([
@@ -336,6 +344,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 			"Postal address missing mandatory fields in postal address", { messageCode: "MISSING_MANDATORY_FIELDS_IN_POSTAL_ADDRESS" },
 		);
 		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "DocSelect_missing_mandatory_fields_in_postal_address", MetricUnits.Count, 1);
+		expect(metrics.addMetric).not.toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it("Should update the TTL on both Session & Person Identity Tables", async () => {
@@ -393,6 +402,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 			"Yoti session already exists for this authorization session or Session is in the wrong state: F2F_YOTI_SESSION_CREATED", { messageCode: "STATE_MISMATCH" },
 		);
 		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "DocSelect_error_user_state_incorrect", MetricUnits.Count, 1);
+		expect(metrics.addMetric).not.toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it("Returns server error if PersonIdentity table is missing emailAddress", async () => {
@@ -413,6 +423,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.error).toHaveBeenCalledWith(
 			"Missing emailAddress in the PERSON IDENTITY table", { "messageCode": MessageCodes.MISSING_PERSON_EMAIL_ADDRESS },
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("Returns server error if PersonIdentity table is missing name", async () => {
@@ -433,6 +444,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.error).toHaveBeenCalledWith(
 			"Missing person's GivenName or FamilyName in the PERSON IDENTITY table", { "messageCode": MessageCodes.MISSING_PERSON_IDENTITY_NAME },
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("Returns server error if GivenName is empty in the PersonIdentity table", async () => {
@@ -466,6 +478,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.error).toHaveBeenCalledWith(
 			"Missing person's GivenName or FamilyName in the PERSON IDENTITY table", { "messageCode": MessageCodes.MISSING_PERSON_IDENTITY_NAME },
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("Returns server error if FamilyName is empty in the PersonIdentity table", async () => {
@@ -499,6 +512,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.error).toHaveBeenCalledWith(
 			"Missing person's GivenName or FamilyName in the PERSON IDENTITY table", { "messageCode": MessageCodes.MISSING_PERSON_IDENTITY_NAME },
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("Throw server error if Yoti Session creation fails", async () => {
@@ -519,6 +533,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.error).toHaveBeenNthCalledWith(2,
 			"Error occurred during documentSelection orchestration", "An error occurred when creating Yoti Session", { "messageCode": "FAILED_DOCUMENT_SELECTION_ORCHESTRATION" },
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it("Throw server error if Yoti Session info fetch fails", async () => {
@@ -541,6 +556,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.error).toHaveBeenNthCalledWith(2,
 			"Error occurred during documentSelection orchestration", "An error occurred when fetching Yoti Session", { "messageCode": "FAILED_DOCUMENT_SELECTION_ORCHESTRATION" },
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it("Throw server error if Yoti pdf generation fails", async () => {
@@ -566,7 +582,7 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.error).toHaveBeenNthCalledWith(2,
 			"Error occurred during documentSelection orchestration", "An error occurred when generating Yoti instructions pdf", { "messageCode": "FAILED_DOCUMENT_SELECTION_ORCHESTRATION" },
 		);
-
+		expect(metrics.addMetric).not.toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it("Return 200 when write to txMA fails", async () => {
@@ -615,6 +631,8 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(logger.error).toHaveBeenNthCalledWith(2,
 			"Error occurred during documentSelection orchestration", "An error occurred when sending message to GovNotify handler", { "messageCode": "FAILED_DOCUMENT_SELECTION_ORCHESTRATION" },
 		);
+		expect(metrics.addMetric).toHaveBeenCalledWith("DocSelect_pdf_email_added_to_queue", MetricUnits.Count, 1)
+		expect(metrics.addMetric).not.toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it("Return 500 when updating the session returns an error", async () => {
@@ -636,6 +654,8 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(mockF2fService.sendToGovNotify).toHaveBeenCalledTimes(1);
 		expect(out.statusCode).toBe(HttpCodesEnum.SERVER_ERROR);
 		expect(out.body).toBe("An error has occurred");
+		expect(metrics.addMetric).toHaveBeenCalledWith("DocSelect_pdf_email_added_to_queue", MetricUnits.Count, 1)
+		expect(metrics.addMetric).not.toHaveBeenCalledWith("state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it("Return 500 when updating the TTLs returns an error", async () => {
@@ -660,6 +680,8 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(mockF2fService.sendToGovNotify).toHaveBeenCalledTimes(1);
 		expect(out.statusCode).toBe(HttpCodesEnum.SERVER_ERROR);
 		expect(out.body).toBe("An error has occurred");
+		expect(metrics.addMetric).toHaveBeenCalledWith("DocSelect_pdf_email_added_to_queue", MetricUnits.Count, 1)
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it("Return 500 when add users documentUsed returns an error", async () => {
@@ -680,6 +702,8 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(mockF2fService.sendToGovNotify).toHaveBeenCalledTimes(1);
 		expect(out.statusCode).toBe(HttpCodesEnum.SERVER_ERROR);
 		expect(out.body).toBe("An error has occurred");
+		expect(metrics.addMetric).toHaveBeenCalledWith("DocSelect_pdf_email_added_to_queue", MetricUnits.Count, 1)
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
 	});
 
 	it.each([
@@ -712,8 +736,9 @@ describe("DocumentSelectionRequestProcessor", () => {
 		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "DocSelect_comms_choice", MetricUnits.Count, 1);
 	
 		expect(metrics.addDimension).toHaveBeenNthCalledWith(2, "document_type", "ukPassport");
-		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "DocSelect_document_selected", MetricUnits.Count, 1);
-		expect(metrics.addMetric).toHaveBeenNthCalledWith(4, "DocSelect_doc_select_complete", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "state-F2F_YOTI_SESSION_CREATED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(4, "DocSelect_document_selected", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(5, "DocSelect_doc_select_complete", MetricUnits.Count, 1);
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 
 	});

--- a/src/tests/unit/services/PdfGenerationService.test.ts
+++ b/src/tests/unit/services/PdfGenerationService.test.ts
@@ -8,11 +8,14 @@ import { mock } from "jest-mock-extended";
 import { PersonIdentityAddress, PersonIdentityItem } from "../../../models/PersonIdentityItem";
 import { F2fService } from "../../../services/F2fService";
 import { PDFGenerationService } from "../../../services/pdfGenerationService";
+import { Metrics } from "@aws-lambda-powertools/metrics";
 
 let pdfGenerationService: PDFGenerationService;
 const mockF2fService = mock<F2fService>();
 
 const logger = mock<Logger>();
+const metrics = mock<Metrics>();
+
 const sessionId = "sessionId";
 
 const person: PersonIdentityItem = {
@@ -62,7 +65,7 @@ const person: PersonIdentityItem = {
 
 describe("PdfGenerationServiceTest", () => {
 	beforeAll(() => {
-		pdfGenerationService = PDFGenerationService.getInstance(logger);
+		pdfGenerationService = PDFGenerationService.getInstance(logger, metrics);
 		// @ts-expect-error linting to be updated
 		pdfGenerationService.f2fService = mockF2fService;
 	});

--- a/src/tests/unit/services/SendEmailProcessor.test.ts
+++ b/src/tests/unit/services/SendEmailProcessor.test.ts
@@ -1,4 +1,4 @@
-import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { SQSEvent } from "aws-lambda";
 import { VALID_SQS_EVENT, VALID_DYNAMIC_REMINDER_SQS_EVENT, VALID_REMINDER_SQS_EVENT } from "../data/sqs-events";
@@ -17,7 +17,7 @@ const logger = new Logger({
 	logLevel: "DEBUG",
 	serviceName: "F2F",
 });
-const metrics = new Metrics({ namespace: "F2F" });
+const metrics = mock<Metrics>();
 let sqsEvent: SQSEvent;
 let reminderEmailEvent: SQSEvent;
 let dynamicEmailEvent: SQSEvent;
@@ -36,6 +36,7 @@ describe("SendEmailProcessor", () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		sqsEvent = VALID_SQS_EVENT;
+		metrics.singleMetric.mockReturnValue(metrics);
 	});
 
 	describe("PDF_EMAIL", () => {
@@ -48,6 +49,9 @@ describe("SendEmailProcessor", () => {
 
 			expect(emailResponse?.emailSentDateTime).toEqual(expectedDateTime);
 			expect(emailResponse?.emailFailureMessage).toBe("");
+			expect(metrics.addDimension).toHaveBeenCalledWith("emailType", "Pdf");
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "GovNotify_email_sent", MetricUnits.Count, 1);
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "GovNotify_PDF_email_sent", MetricUnits.Count, 1);
 		});
 
 		it.each([
@@ -60,6 +64,7 @@ describe("SendEmailProcessor", () => {
 			delete eventBodyMessage[attribute];
 			eventBody.Message = eventBodyMessage;
 			await expect(sendEmailProcessorTest.processRequest(eventBody)).rejects.toThrow();
+			expect(metrics.addMetric).not.toHaveBeenCalled();
 		});
 	});
 
@@ -73,6 +78,8 @@ describe("SendEmailProcessor", () => {
 
 			expect(emailResponse?.emailSentDateTime).toEqual(expectedDateTime);
 			expect(emailResponse?.emailFailureMessage).toBe("");
+			expect(metrics.addDimension).toHaveBeenCalledWith("emailType", "reminder");
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "GovNotify_email_sent", MetricUnits.Count, 1);
 		});
 
 		it.each([
@@ -83,6 +90,7 @@ describe("SendEmailProcessor", () => {
 			delete eventBodyMessage[attribute];
 			eventBody.Message = eventBodyMessage;
 			await expect(sendEmailProcessorTest.processRequest(eventBody)).rejects.toThrow();
+			expect(metrics.addMetric).not.toHaveBeenCalled();
 		});
 	});
 
@@ -96,6 +104,8 @@ describe("SendEmailProcessor", () => {
 
 			expect(emailResponse?.emailSentDateTime).toEqual(expectedDateTime);
 			expect(emailResponse?.emailFailureMessage).toBe("");
+			expect(metrics.addDimension).toHaveBeenCalledWith("emailType", "dynamic_reminder");
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "GovNotify_email_sent", MetricUnits.Count, 1);
 		});
 
 		it.each([
@@ -110,6 +120,7 @@ describe("SendEmailProcessor", () => {
 			delete eventBodyMessage[attribute];
 			eventBody.Message = eventBodyMessage;
 			await expect(sendEmailProcessorTest.processRequest(eventBody)).rejects.toThrow();
+			expect(metrics.addMetric).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/tests/unit/services/SessionRequestProcessor.test.ts
+++ b/src/tests/unit/services/SessionRequestProcessor.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 /* eslint-disable max-lines-per-function */
 import { SessionRequestProcessor } from "../../../services/SessionRequestProcessor";
-import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { mock } from "jest-mock-extended";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { F2fService } from "../../../services/F2fService";
@@ -152,6 +152,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: MessageCodes.UNRECOGNISED_CLIENT,
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should report a JWE decryption failure", async () => {
@@ -167,6 +168,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: MessageCodes.FAILED_DECRYPTING_JWE,
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should report a failure to decode JWT", async () => {
@@ -185,6 +187,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: MessageCodes.FAILED_DECODING_JWT,
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should report a JWT verification failure", async () => {
@@ -202,6 +205,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: MessageCodes.FAILED_VERIFYING_JWT,
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should report an unexpected error verifying JWT", async () => {
@@ -219,6 +223,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: MessageCodes.FAILED_VERIFYING_JWT,
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should report a JWT validation failure", async () => {
@@ -236,6 +241,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: "FAILED_VALIDATING_JWT",
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should report invalid address countryCode failure", async () => {
@@ -255,6 +261,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: MessageCodes.INVALID_COUNTRY_CODE,
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should report invalid address format failure", async () => {
@@ -274,6 +281,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: MessageCodes.MISSING_ALL_MANDATORY_POSTAL_ADDRESS_FIELDS,
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should return unauthorized when emailAddress is missing in the sharedClaim data", async () => {
@@ -293,6 +301,7 @@ describe("SessionRequestProcessor", () => {
 				messageCode: MessageCodes.MISSING_PERSON_EMAIL_ADDRESS,
 			}),
 		);
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should report session already exists", async () => {
@@ -318,6 +327,7 @@ describe("SessionRequestProcessor", () => {
 			sessionId: expect.any(String),
 			govuk_signin_journey_id: "abcdef",
 		});
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should fail to create a session", async () => {
@@ -344,6 +354,7 @@ describe("SessionRequestProcessor", () => {
 			sessionId: expect.any(String),
 			govuk_signin_journey_id: "abcdef",
 		});
+		expect(metrics.addMetric).not.toHaveBeenCalled();
 	});
 
 	it("should create a new session", async () => {
@@ -367,6 +378,8 @@ describe("SessionRequestProcessor", () => {
 			sessionId: expect.any(String),
 			govuk_signin_journey_id: "abcdef",
 		});
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "state-F2F_SESSION_CREATED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "session_created", MetricUnits.Count, 1)
 	});
 
 	it("ip_address is X_FORWARDED_FOR header if present in event header", async () => {
@@ -445,6 +458,8 @@ describe("SessionRequestProcessor", () => {
 			sessionId: expect.any(String),
 			govuk_signin_journey_id: "abcdef",
 		});
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "state-F2F_SESSION_CREATED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "session_created", MetricUnits.Count, 1)
 	});
 
 	// the test below fails as the session processor is not writing the expiryDate value correctly in

--- a/src/tests/unit/services/ThankYouEmailProcessor.test.ts
+++ b/src/tests/unit/services/ThankYouEmailProcessor.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines-per-function */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Logger } from "@aws-lambda-powertools/logger";
-import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { mock } from "jest-mock-extended";
 import { AuthSessionState } from "../../../models/enums/AuthSessionState";
 import { MessageCodes } from "../../../models/enums/MessageCodes";
@@ -17,7 +17,7 @@ import { mockYotiSessionItemBST, mockYotiSessionItemGMT } from "../data/yoti-ses
 const mockF2fService = mock<F2fService>();
 const mockYotiService = mock<YotiService>();
 const logger = mock<Logger>();
-const metrics = new Metrics({ namespace: "F2F" });
+const metrics = mock<Metrics>();
 // pragma: allowlist nextline secret
 const YOTI_PRIVATE_KEY = "YOTI_PRIVATE_KEY";
 const sessionId = "RandomF2FSessionID";
@@ -80,6 +80,7 @@ describe("ThankYouEmailProcessor", () => {
 			expect(logger.error).toHaveBeenCalledWith("Event does not include yoti session_id", {
 				messageCode: MessageCodes.MISSING_SESSION_ID,
 			});
+			expect(metrics.addMetric).not.toHaveBeenCalled();
 		});
 
 		it("throws error if F2F session can't be found", async () => {
@@ -92,6 +93,7 @@ describe("ThankYouEmailProcessor", () => {
 			expect(logger.error).toHaveBeenCalledWith("Session not found", {
 				messageCode: MessageCodes.SESSION_NOT_FOUND,
 			});
+			expect(metrics.addMetric).not.toHaveBeenCalled();
 		});
 
 		it("throws error if yoti session can't be found", async () => {
@@ -106,6 +108,7 @@ describe("ThankYouEmailProcessor", () => {
 				yotiSessionID: sessionId,
 				messageCode: MessageCodes.VENDOR_SESSION_NOT_FOUND,
 			});
+			expect(metrics.addMetric).not.toHaveBeenCalled();
 		});
 
 		it("sends correctly formatted message to TxMA if all checks pass", async () => {
@@ -133,6 +136,7 @@ describe("ThankYouEmailProcessor", () => {
   			},
 			});
 			expect(logger.info).toHaveBeenCalledWith("Post office visit details", { postOfficeDateOfVisit: "7 February 2023", postOfficeTimeOfVisit: "2:30 pm" });
+			expect(metrics.addMetric).toHaveBeenCalledWith("document_uploaded_at_PO", MetricUnits.Count, 1);
 		});
 
 		it("adjusts for BST correctly", async () => {
@@ -161,6 +165,7 @@ describe("ThankYouEmailProcessor", () => {
   			},
 			});
 			expect(logger.info).toHaveBeenCalledWith("Post office visit details", { postOfficeDateOfVisit: "7 September 2023", postOfficeTimeOfVisit: "3:30 pm" });
+			expect(metrics.addMetric).toHaveBeenCalledWith("document_uploaded_at_PO", MetricUnits.Count, 1);
 		});
 	});
 });

--- a/src/tests/unit/services/YotiSessionCompletionProcessor.test.ts
+++ b/src/tests/unit/services/YotiSessionCompletionProcessor.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 /* eslint-disable max-lines-per-function */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Metrics } from "@aws-lambda-powertools/metrics";
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
 import { mock } from "jest-mock-extended";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { F2fService } from "../../../services/F2fService";
@@ -27,7 +27,7 @@ const mockF2fService = mock<F2fService>();
 const mockYotiService = mock<YotiService>();
 
 const logger = mock<Logger>();
-const metrics = new Metrics({ namespace: "F2F" });
+const metrics = mock<Metrics>();
 jest.mock("crypto", () => ({
 	...jest.requireActual("crypto"),
 	randomUUID: () => "sdfsdf",
@@ -228,6 +228,10 @@ describe("YotiSessionCompletionProcessor", () => {
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("OK");
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
+
 	});
 
 	it("Return successful response with 200 OK when YOTI session created with driving permit", async () => {
@@ -331,6 +335,9 @@ describe("YotiSessionCompletionProcessor", () => {
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("OK");
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 	});
 
 	it("Return successful response with 200 OK when YOTI session is completed for driving permit- Media not containing formatted_address", async () => {
@@ -434,6 +441,9 @@ describe("YotiSessionCompletionProcessor", () => {
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("OK");
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 	});
 
 	it("Return successful response with 200 OK when YOTI session is completed for driving permit- Media not containing structured_postal_address", async () => {
@@ -529,6 +539,9 @@ describe("YotiSessionCompletionProcessor", () => {
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("OK");
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 	});
 
 	it("Return successful response with 200 OK when YOTI session created with EU driving permit", async () => {
@@ -629,6 +642,9 @@ describe("YotiSessionCompletionProcessor", () => {
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("OK");
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 	});
 
 	it("Return successful response with 200 OK when YOTI session created with EEA Identity Card", async () => {
@@ -726,6 +742,9 @@ describe("YotiSessionCompletionProcessor", () => {
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.OK);
 		expect(out.body).toBe("OK");
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 	});
 
 	describe("name checks", () => {
@@ -738,6 +757,9 @@ describe("YotiSessionCompletionProcessor", () => {
 
 			await mockCompletedSessionProcessor.processRequest(VALID_REQUEST);
 			expect(logger.info).toHaveBeenCalledWith("Getting NameParts using Yoti DocumentFields Info");
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);	
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 		});	
 
 		it("Should call getNamesFromPersonIdentity if DocumentFields does not contain given_name", async () => {
@@ -755,6 +777,9 @@ describe("YotiSessionCompletionProcessor", () => {
 			await mockCompletedSessionProcessor.processRequest(VALID_REQUEST);
 
 			expect(logger.info).toHaveBeenCalledWith("Getting NameParts using F2F Person Identity Info");
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);	
 		});	
 
 		it("Should use name casing from documentFields when using getNamesFromPersonIdentity", async () => {
@@ -841,6 +866,9 @@ describe("YotiSessionCompletionProcessor", () => {
 					},
 		 })],
 			});
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);		expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
+			expect(metrics.addMetric).toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 		});
 
 		it("Should throw an error of name mismatch between F2F and Yoti DocumentFields", async () => {
@@ -855,10 +883,11 @@ describe("YotiSessionCompletionProcessor", () => {
 			// @ts-expect-error linting to be updated
 			mockCompletedSessionProcessor.verifiableCredentialService.kmsJwtAdapter = passingKmsJwtAdapterFactory();
 
-			return expect(mockCompletedSessionProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
+			expect(mockCompletedSessionProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
 				statusCode: HttpCodesEnum.SERVER_ERROR,
 				message: "FullName mismatch between F2F & YOTI",
 			}));
+			expect(metrics.addMetric).not.toHaveBeenCalled()
 		});
 	});
 
@@ -880,6 +909,7 @@ describe("YotiSessionCompletionProcessor", () => {
 				error: "access_denied",
     			error_description: "VC generation failed : Yoti Session not found",
 			});
+			expect(metrics.addMetric).not.toHaveBeenCalled()
 		});
 
 		it("Throws server error if session in Yoti is not completed", async () => {
@@ -901,6 +931,7 @@ describe("YotiSessionCompletionProcessor", () => {
 				error: "access_denied",
     			error_description: "VC generation failed : Yoti Session not complete",
 			});
+			expect(metrics.addMetric).not.toHaveBeenCalled()
 		});
 
 		it("Throws server error if session in Yoti does not contain document fields", async () => {
@@ -978,6 +1009,7 @@ describe("YotiSessionCompletionProcessor", () => {
 				error: "access_denied",
     			error_description: "VC generation failed : Yoti document_fields not populated",
 			});
+			expect(metrics.addMetric).not.toHaveBeenCalled()
 		});
 
 		it("Throws server error if session in Yoti contains multiple document_field entries", async () => {
@@ -1004,6 +1036,7 @@ describe("YotiSessionCompletionProcessor", () => {
 				error: "access_denied",
     			error_description: "VC generation failed : Multiple document_fields in response",
 			});
+			expect(metrics.addMetric).not.toHaveBeenCalled()
 		});
 
 		it("Throws server error if session in Yoti does not contain media ID", async () => {
@@ -1026,6 +1059,7 @@ describe("YotiSessionCompletionProcessor", () => {
 				error: "access_denied",
     			error_description: "VC generation failed : Yoti document_fields media ID not found",
 			});
+			expect(metrics.addMetric).not.toHaveBeenCalled()
 		});
 	});
 
@@ -1038,6 +1072,7 @@ describe("YotiSessionCompletionProcessor", () => {
 			statusCode: HttpCodesEnum.SERVER_ERROR,
 			message: "Missing Info in Session Table",
 		}));
+		expect(metrics.addMetric).not.toHaveBeenCalled()
 	});
 
 	it("Should throw an error when session is in wrong AuthSessionState", async () => {
@@ -1059,7 +1094,8 @@ describe("YotiSessionCompletionProcessor", () => {
 			error_description: "VC generation failed : AuthSession is in wrong Auth state",
 		});
 		expect(out.statusCode).toBe(HttpCodesEnum.UNAUTHORIZED);
-		expect(out.body).toBe("AuthSession is in wrong Auth state: Expected state- F2F_ACCESS_TOKEN_ISSUED or F2F_AUTH_CODE_ISSUED, actual state- F2F_YOTI_SESSION_CREATED");		
+		expect(out.body).toBe("AuthSession is in wrong Auth state: Expected state- F2F_ACCESS_TOKEN_ISSUED or F2F_AUTH_CODE_ISSUED, actual state- F2F_YOTI_SESSION_CREATED");
+		expect(metrics.addMetric).not.toHaveBeenCalled()		
 	});
 
 	it("Return 200 when write to txMA fails", async () => {
@@ -1090,10 +1126,11 @@ describe("YotiSessionCompletionProcessor", () => {
 
 		mockF2fService.sendToIPVCore.mockRejectedValueOnce("Failed to send to IPV Core");
 
-		return expect(mockCompletedSessionProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
+		expect(mockCompletedSessionProcessor.processRequest(VALID_REQUEST)).rejects.toThrow(expect.objectContaining({
 			statusCode: HttpCodesEnum.SERVER_ERROR,
 			message: "Failed to send to IPV Core",
-		}));		
+		}));
+		expect(metrics.addMetric).not.toHaveBeenCalled()		
 	});
 
 	it("Throws server error if signGeneratedVerifiableCredentialJwt returns empty string", async () => {
@@ -1116,6 +1153,9 @@ describe("YotiSessionCompletionProcessor", () => {
 			error: "access_denied",
 			error_description: "VC generation failed : Unable to create signed JWT",
 		});
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).not.toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).not.toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
 	});
 
 	it("Returns server error response if signGeneratedVerifiableCredentialJwt throws error", async () => {
@@ -1138,6 +1178,10 @@ describe("YotiSessionCompletionProcessor", () => {
 			error: "access_denied",
 			error_description: "VC generation failed : Failed to sign the verifiableCredential Jwt",
 		});
+		expect(metrics.addMetric).toHaveBeenNthCalledWith(1, "SessionCompletion_yoti_response_parsed", MetricUnits.Count, 1);
+		expect(metrics.addMetric).not.toHaveBeenNthCalledWith(2, "state-F2F_CREDENTIAL_ISSUED", MetricUnits.Count, 1);
+		expect(metrics.addMetric).not.toHaveBeenNthCalledWith(3, "SessionCompletion_VC_issued_successfully", MetricUnits.Count, 1);
+	
 	});
 	
 	describe("isTaskDone function", () => {


### PR DESCRIPTION
## Proposed changes

### What changed

Added metrics to cover 6 key aspects of the journey.

1. When a user sessions created successfully in F2F
2. When a user clicks submit on check details page
3. When a user is sent their confirmation email
4. When /userInfo endpoint is hit by IPV core to retrieve a pending VC
5. When a user goes to PO and document is uploaded to Yoti
6. When checks are successfully carried out on Yoti document

As well as key state transitions:

- F2F_SESSION_CREATED
- F2F_YOTI_SESSION_CREATED 
- F2F_AUTH_CODE_ISSUED 
- F2F_ACCESS_TOKEN_ISSUED
- F2F_YOTI_SESSION_COMPLETE 
- F2F_CREDENTIAL_ISSUED 
- F2F_SESSION_ABORTED 
- F2F_CRI_SESSION_ABORTED 
- F2F_SESSION_EXPIRED 

Dashboard update to follow this PR

### Why did it change

To allow us to more easily track F2F journeys and drop outs

