### PR TITLE
[KIWI-2269] - F2F | OAuth | Enable testing failed signature validation with IPV Core Stub

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,28 +127,28 @@
         "filename": "f2f-ipv-stub/src/tests/startF2fCheck.test.ts",
         "hashed_secret": "331246d763e14484171c9d11d9f8f13a3c5842d0",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 24
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "f2f-ipv-stub/src/tests/startF2fCheck.test.ts",
         "hashed_secret": "06b66f906dc54669a3abb655a5f219883c75c7ce",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "f2f-ipv-stub/src/tests/startF2fCheck.test.ts",
         "hashed_secret": "8a0b7528a13ef0bdf5cc99675c0a5919f1998241",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 33
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "f2f-ipv-stub/src/tests/startF2fCheck.test.ts",
         "hashed_secret": "a3c245bf6fbf840b35266611015d433cb1912c1d",
         "is_verified": false,
-        "line_number": 67
+        "line_number": 76
       }
     ],
     "src/jest.setup.ts": [
@@ -234,7 +234,30 @@
         "is_verified": false,
         "line_number": 48
       }
+    ],
+    "src/tests/unit/utils/KmsJwtAdapterUtils.test.ts": [
+      {
+        "type": "JSON Web Token",
+        "filename": "src/tests/unit/utils/KmsJwtAdapterUtils.test.ts",
+        "hashed_secret": "39d2e0e65bb6e9f9068a674c0ce7251ffdab0b80",
+        "is_verified": false,
+        "line_number": 105
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/tests/unit/utils/KmsJwtAdapterUtils.test.ts",
+        "hashed_secret": "7ede38f0a6fe171d89cd44dda2e7c9d528313583",
+        "is_verified": false,
+        "line_number": 110
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/tests/unit/utils/KmsJwtAdapterUtils.test.ts",
+        "hashed_secret": "5943b73cd434ca582a088166b25d19156fba4d1f",
+        "is_verified": false,
+        "line_number": 111
+      }
     ]
   },
-  "generated_at": "2025-04-17T10:28:40Z"
+  "generated_at": "2025-04-24T15:13:19Z"
 }

--- a/f2f-ipv-stub/src/events/startCustomInvalidSigningKey.json
+++ b/f2f-ipv-stub/src/events/startCustomInvalidSigningKey.json
@@ -1,0 +1,26 @@
+
+{
+    "resource": "/",
+    "path": "/start",
+    "httpMethod": "POST",
+    "requestContext": {
+        "resourcePath": "/",
+        "httpMethod": "POST",
+        "path": "/start"
+    },
+    "headers": {
+        "accept": "application/json;charset=UTF-8",
+        "Content-Type": "application/json;charset=UTF-8",
+        "Host": "tests.gov.uk",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+        "X-Amzn-Trace-Id": "Root=1-5e66d96f-7491f09xmpl79d18acf3d050"
+    },
+    "queryStringParameters": {
+    },
+    "multiValueHeaders": {},
+    "multiValueQueryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "body": "{\"invalidKid\":\"true\"}",
+    "isBase64Encoded": false
+}

--- a/f2f-ipv-stub/template.yaml
+++ b/f2f-ipv-stub/template.yaml
@@ -300,6 +300,7 @@ Resources:
       Environment:
         Variables:
           SIGNING_KEY: !Ref IPVStubKMSSigningKey
+          ADDITIONAL_KEY: !Ref IPVStubKMSAdditionalKey
           CLIENT_ID: !FindInMap [Configuration, !Ref Environment, IPVStubID]
           REDIRECT_URI: !If
           - CreateDevResources

--- a/f2f-ipv-stub/template.yaml
+++ b/f2f-ipv-stub/template.yaml
@@ -362,6 +362,7 @@ Resources:
       Environment:
         Variables:
           SIGNING_KEY: !Ref IPVStubKMSSigningKey
+          ADDITIONAL_KEY: !Ref IPVStubKMSAdditionalKey
       Policies:
         - Statement:
             - Sid: KMSSignPolicy

--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -114,13 +114,14 @@ export class SessionRequestProcessor {
   	}
 
   	const jwtPayload: JwtPayload = parsedJwt.payload;
+	const jwtTargetKid: string | undefined = parsedJwt.header?.kid;
   	this.logger.appendKeys({
   		govuk_signin_journey_id: jwtPayload.govuk_signin_journey_id as string,
   		sessionId,
   	});
   	try {
   		if (configClient?.jwksEndpoint) {
-  			const payload = await this.kmsDecryptor.verifyWithJwks(urlEncodedJwt, configClient.jwksEndpoint);
+  			const payload = await this.kmsDecryptor.verifyWithJwks(urlEncodedJwt, configClient.jwksEndpoint, jwtTargetKid);
   			if (!payload) {
   				this.logger.error("Failed to verify JWT", {
   					messageCode: MessageCodes.FAILED_VERIFYING_JWT,

--- a/src/tests/unit/utils/KmsJwtAdapterUtils.test.ts
+++ b/src/tests/unit/utils/KmsJwtAdapterUtils.test.ts
@@ -4,6 +4,9 @@ import { KmsJwtAdapter } from "../../../utils/KmsJwtAdapter";
 import { Constants } from "../../../utils/Constants";
 import { absoluteTimeNow } from "../../../utils/DateTimeUtils";
 import { jwtUtils } from "../../../utils/JwtUtils";
+import axios from "axios";
+
+jest.mock('axios');
 
 jest.mock("ecdsa-sig-formatter", () => ({
 	derToJose: jest.fn().mockImplementation(() => "JOSE-formatted signature"),
@@ -94,6 +97,34 @@ describe("KmsJwtAdapter utils", () => {
 			await expect(kmsJwtAdapter.verify("header.payload.signature")).rejects.toThrow(expect.objectContaining({ message: "Failed to verify signature: Error: cannot verify signature" }));
 		});
 	});
+
+	describe("#verifyWithJwks", () => {
+		const mockPublicKeyEndpoint = 'https://example.com/jwks';
+		const mockTargetKid = '1234';
+		// JWT has 'exp' value set to Friday, 9 March 2125 12:58:39 to ensure jose.jwtVerify() always passes
+		const encodedJwt = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ijg2NTRmYmMxLTExMjEtNGIzOC1iMDM2LTAxM2RmODRjYmNlYyJ9.eyJzdWIiOiIyOTk4NmRkNS0wMWVjLTQyMzYtYWMyMS01ODQ1ZmRhZmQ5YjUiLCJyZWRpcmVjdF91cmkiOiJodHRwczovL2lwdnN0dWIucmV2aWV3LWMuZGV2LmFjY291bnQuZ292LnVrL3JlZGlyZWN0IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJnb3Z1a19zaWduaW5fam91cm5leV9pZCI6Ijg4Y2UxNmUxZTU5MTkxZjE0YzlkMzU3MDk4M2JiYTg3IiwiYXVkIjoiaHR0cHM6Ly9jaWMtY3JpLWZyb250LnJldmlldy1jLmRldi5hY2NvdW50Lmdvdi51ayIsImlzcyI6Imh0dHBzOi8vaXB2LmNvcmUuYWNjb3VudC5nb3YudWsiLCJjbGllbnRfaWQiOiI1QzU4NDU3MiIsInN0YXRlIjoiZGYyMjVjNzdlN2MzOWU4ODJjM2FhNzc0NjcyMGM0NjUiLCJpYXQiOjE3NDM1OTg3MTksIm5iZiI6MTc0MzU5ODcxOCwiZXhwIjo0ODk3MTk4NzE5LCJzaGFyZWRfY2xhaW1zIjp7Im5hbWUiOlt7Im5hbWVQYXJ0cyI6W3sidmFsdWUiOiJGcmVkZXJpY2siLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6Ikpvc2VwaCIsInR5cGUiOiJHaXZlbk5hbWUifSx7InZhbHVlIjoiRmxpbnRzdG9uZSIsInR5cGUiOiJGYW1pbHlOYW1lIn1dfV0sImJpcnRoRGF0ZSI6W3sidmFsdWUiOiIxOTYwLTAyLTAyIn1dLCJlbWFpbCI6ImV4YW1wbGVAdGVzdGVtYWlsLmNvbSJ9fQ.7M7WQqMK1cp8zin6Rb2ZBxmxvsjc3vWTjdHpKYJApvzdXo6S1lxRK52l-rJR3AeBW7QS-28j6PW4LhgkX6O1mA"
+		const mockJwksResponse = {
+			"keys": [
+			  {
+				kty: "EC",
+				x: "5KIC1DrBMWrwOUMc-xEph9D_jfGeG9uOMJcuJ9g8Yic",
+				y: "xMQcIwuJonk4nY9x7opfJ2bJPtFA2PECu1hXruK2osM",
+				crv: "P-256",
+				use: "sig",
+				kid: "1234",
+				alg: "ES256"
+			  }
+			]
+		}
+		
+		it("verifies a JWT and returns a payload", async () => {
+			(axios.get as jest.Mock).mockResolvedValue({ data: mockJwksResponse });
+			const result = await kmsJwtAdapter.verifyWithJwks(encodedJwt, mockPublicKeyEndpoint, mockTargetKid);
+			expect(axios.get).toHaveBeenCalledWith(mockPublicKeyEndpoint);
+    		expect(result?.sub).toEqual("29986dd5-01ec-4236-ac21-5845fdafd9b5");
+		});
+	});
+	
 
 	describe("#decode", () => {
 		it("returns correctly formatted result", () => {

--- a/src/utils/KmsJwtAdapter.ts
+++ b/src/utils/KmsJwtAdapter.ts
@@ -69,7 +69,6 @@ export class KmsJwtAdapter {
 
 	async verifyWithJwks(urlEncodedJwt: string, publicKeyEndpoint: string, targetKid?: string): Promise<JWTPayload | null> {
 		const oidcProviderJwks = (await axios.get(publicKeyEndpoint)).data;
-		console.log("!!!", oidcProviderJwks);
 		const signingKey = oidcProviderJwks.keys.find((key: Jwk) => key.kid === targetKid);
 
 		if (!signingKey) {

--- a/src/utils/KmsJwtAdapter.ts
+++ b/src/utils/KmsJwtAdapter.ts
@@ -67,9 +67,14 @@ export class KmsJwtAdapter {
 		}
 	}
 
-	async verifyWithJwks(urlEncodedJwt: string, publicKeyEndpoint: string): Promise<JWTPayload | null> {
+	async verifyWithJwks(urlEncodedJwt: string, publicKeyEndpoint: string, targetKid?: string): Promise<JWTPayload | null> {
 		const oidcProviderJwks = (await axios.get(publicKeyEndpoint)).data;
-		const signingKey = oidcProviderJwks.keys.find((key: Jwk) => key.use === "sig");
+		const signingKey = oidcProviderJwks.keys.find((key: Jwk) => key.kid === targetKid);
+
+		if (!signingKey) {
+			throw new Error(`No key found with kid '${targetKid}'`);
+		}
+
 		const publicKey = await importJWK(signingKey, signingKey.alg);
 
 		try {

--- a/src/utils/KmsJwtAdapter.ts
+++ b/src/utils/KmsJwtAdapter.ts
@@ -69,6 +69,7 @@ export class KmsJwtAdapter {
 
 	async verifyWithJwks(urlEncodedJwt: string, publicKeyEndpoint: string, targetKid?: string): Promise<JWTPayload | null> {
 		const oidcProviderJwks = (await axios.get(publicKeyEndpoint)).data;
+		console.log("!!!", oidcProviderJwks);
 		const signingKey = oidcProviderJwks.keys.find((key: Jwk) => key.kid === targetKid);
 
 		if (!signingKey) {


### PR DESCRIPTION
### What changed

Added invalid and missingKid overrides to IPV core stub

### Why did it change

To test for failed JWK verification

### Issue tracking

- [KIWI-2269](https://govukverify.atlassian.net/browse/KIWI-2269)


[KIWI-2269]: https://govukverify.atlassian.net/browse/KIWI-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ