### PR TITLE
[KIWI-2335] - F2F | OAuth | Move public encryption keys to new S3

### DIFF
--- a/deploy/f2f-spec.yaml
+++ b/deploy/f2f-spec.yaml
@@ -657,7 +657,7 @@ paths:
         credentials:
           Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/${JsonWebKeysBucket}/.well-known/jwks.json"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-f2f-published-keys-${Environment}/jwks.json"
         responses:
           default:
             statusCode: "200"

--- a/deploy/f2f-spec.yaml
+++ b/deploy/f2f-spec.yaml
@@ -657,7 +657,7 @@ paths:
         credentials:
           Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-f2f-published-keys-${Environment}/jwks.json"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/${JsonWebKeysBucket}/.well-known/jwks.json"
         responses:
           default:
             statusCode: "200"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -597,6 +597,11 @@ Resources:
                   - "s3:Get*"
                 Resource:
                   - !Sub "arn:aws:s3:::${JsonWebKeysBucket}/.well-known/jwks.json"
+              - Effect: Allow
+                Action:
+                  - "s3:Get*"
+                Resource:
+                  - !Sub "arn:aws:s3:::govuk-one-login-f2f-published-keys-${Environment}/jwks.json"
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
@@ -3252,12 +3257,18 @@ Resources:
         - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
+      Tags:
+        key_consumer_type: manage
       Policies:
         - AWSXRayDaemonWriteAccess
         - S3WritePolicy:
             BucketName: !Ref JsonWebKeysBucket
         - S3ReadPolicy:
             BucketName: !Ref JsonWebKeysBucket
+        - S3ReadPolicy:
+            BucketName: !Sub "govuk-one-login-f2f-published-keys-${Environment}"
+        - S3WritePolicy:
+            BucketName: !Sub "govuk-one-login-f2f-published-keys-${Environment}"
         - Statement:
             - Sid: KMSSignPolicy
               Effect: Allow
@@ -3275,6 +3286,7 @@ Resources:
       Environment:
         Variables:
           JWKS_BUCKET_NAME: !Ref JsonWebKeysBucket
+          PUBLISHED_KEYS_BUCKET_NAME: !Sub "govuk-one-login-f2f-published-keys-${Environment}"
           SIGNING_KEY_IDS:
             Fn::ImportValue: !Sub "${L2KMSStackName}-vc-signing-key"
           ENCRYPTION_KEY_IDS:

--- a/src/JwksHandler.ts
+++ b/src/JwksHandler.ts
@@ -52,9 +52,9 @@ class JwksHandler implements LambdaInterface {
 
         const uploadParams = {
             Bucket: JWKS_BUCKET_NAME,
-        Key: ".well-known/jwks.json",
-        Body: JSON.stringify(body),
-        ContentType: "application/json",
+			Key: ".well-known/jwks.json",
+			Body: JSON.stringify(body),
+			ContentType: "application/json",
         };
 
 		const copyParams = {

--- a/src/JwksHandler.ts
+++ b/src/JwksHandler.ts
@@ -13,37 +13,36 @@ const POWERTOOLS_LOG_LEVEL = process.env.POWERTOOLS_LOG_LEVEL ? process.env.POWE
 const POWERTOOLS_SERVICE_NAME = process.env.POWERTOOLS_SERVICE_NAME ? process.env.POWERTOOLS_SERVICE_NAME : Constants.JWKS_LOGGER_SVC_NAME;
 const JWKS_BUCKET_NAME = process.env.JWKS_BUCKET_NAME;
 const PUBLISHED_KEYS_BUCKET_NAME = process.env.PUBLISHED_KEYS_BUCKET_NAME;
-const logger = new Logger({
+export const logger = new Logger({
 	logLevel: POWERTOOLS_LOG_LEVEL,
 	serviceName: POWERTOOLS_SERVICE_NAME,
 });
 
-const s3Client = new S3Client({
-	region: process.env.REGION,
-	maxAttempts: 2,
-	requestHandler: new NodeHttpHandler({
-		connectionTimeout: 29000,
-		socketTimeout: 29000,
-	}),
-});
-const environmentVariables: EnvironmentVariables = new EnvironmentVariables(logger, ServicesEnum.JWKS_SERVICE);
-
-const kmsClient = new AWS.KMS({
-	region: process.env.REGION,
-});
-
 class JwksHandler implements LambdaInterface {
+	readonly s3Client = new S3Client({
+		region: process.env.REGION,
+		maxAttempts: 2,
+		requestHandler: new NodeHttpHandler({
+			connectionTimeout: 29000,
+			socketTimeout: 29000,
+		}),
+	});
+	readonly environmentVariables: EnvironmentVariables = new EnvironmentVariables(logger, ServicesEnum.JWKS_SERVICE);
+	
+	readonly kmsClient = new AWS.KMS({
+		region: process.env.REGION,
+	});
 
     async handler(): Promise<string> {
         const body: JWKSBody = { keys: [] };
         const kmsKeyIds = [
-            ...environmentVariables.signingKeyIds().split(","),
-            ...environmentVariables.encryptionKeyIds().split(","),
+            ...this.environmentVariables.signingKeyIds().split(","),
+            ...this.environmentVariables.encryptionKeyIds().split(","),
         ];
         logger.info({ message:"Building wellknown JWK endpoint with keys" + kmsKeyIds });
 
         const jwks = await Promise.all(
-            kmsKeyIds.map(async id => getAsJwk(id)),
+            kmsKeyIds.map(async id => this.getAsJwk(id)),
         );
         jwks.forEach(jwk => {
             if (jwk != null) {
@@ -58,18 +57,19 @@ class JwksHandler implements LambdaInterface {
         ContentType: "application/json",
         };
 
+		const copyParams = {
+			Bucket: PUBLISHED_KEYS_BUCKET_NAME,
+			Key: "jwks.json",
+			CopySource: `${JWKS_BUCKET_NAME}/.well-known/jwks.json`,
+		};
+
         try {
             logger.info({ message: "Uploading keys to JWKS bucket" });
-            await s3Client.send(new PutObjectCommand(uploadParams));
+            await this.s3Client.send(new PutObjectCommand(uploadParams));
 
             logger.info({ message: "Copying keys to published keys bucket" });
-            await s3Client.send(
-                new CopyObjectCommand({
-                Bucket: PUBLISHED_KEYS_BUCKET_NAME,
-                Key: "jwks.json",
-                CopySource: `${JWKS_BUCKET_NAME}/.well-known/jwks.json`,
-                }),
-            );
+            await this.s3Client.send(new CopyObjectCommand(copyParams));
+			logger.info({ message: "Keys copied to published keys bucket" });
 
         return JSON.stringify(body);
         } catch (err) {
@@ -78,57 +78,58 @@ class JwksHandler implements LambdaInterface {
         }
 
     }
+
+	async getAsJwk (keyId: string): Promise<Jwk | null> {
+		let kmsKey;
+		try {
+			kmsKey = await this.kmsClient.getPublicKey({ KeyId: keyId });
+		} catch (error) {
+			logger.warn({ message:"Failed to fetch key from KMS" }, { error });
+		}
+	
+		const map = this.getKeySpecMap(kmsKey?.KeySpec);
+		if (
+			kmsKey != null &&
+			map != null &&
+			kmsKey.KeyId != null &&
+			kmsKey.PublicKey != null
+		) {
+			const use = kmsKey.KeyUsage === "ENCRYPT_DECRYPT" ? "enc" : "sig";
+			const publicKey = crypto
+				.createPublicKey({
+					key: kmsKey.PublicKey as Buffer,
+					type: "spki",
+					format: "der",
+				})
+				.export({ format: "jwk" });
+			return {
+				...publicKey,
+				use,
+				kid: keyId.split("/").pop(),
+				alg: map.algorithm,
+			} as unknown as Jwk;
+		}
+		logger.error({ message: "Failed to build JWK from key" + keyId }, JSON.stringify(map));
+		return null;
+	};
+
+	getKeySpecMap (
+		spec?: string,
+	): { keySpec: string; algorithm: Algorithm } | undefined {
+		if (spec == null) return undefined;
+		const conversions = [
+			{
+				keySpec: "ECC_NIST_P256",
+				algorithm: "ES256" as Algorithm,
+			},
+			{
+				keySpec: "RSA_2048",
+				algorithm: "RS256" as Algorithm,
+			},
+		];
+		return conversions.find(x => x.keySpec === spec);
+	};
 }
 
-const getAsJwk = async (keyId: string): Promise<Jwk | null> => {
-	let kmsKey;
-	try {
-		kmsKey = await kmsClient.getPublicKey({ KeyId: keyId });
-	} catch (error) {
-		logger.warn({ message:"Failed to fetch key from KMS" }, { error });
-	}
-
-	const map = getKeySpecMap(kmsKey?.KeySpec);
-	if (
-		kmsKey != null &&
-        map != null &&
-        kmsKey.KeyId != null &&
-        kmsKey.PublicKey != null
-	) {
-		const use = kmsKey.KeyUsage === "ENCRYPT_DECRYPT" ? "enc" : "sig";
-		const publicKey = crypto
-			.createPublicKey({
-				key: kmsKey.PublicKey as Buffer,
-				type: "spki",
-				format: "der",
-			})
-			.export({ format: "jwk" });
-		return {
-			...publicKey,
-			use,
-			kid: keyId.split("/").pop(),
-			alg: map.algorithm,
-		} as unknown as Jwk;
-	}
-	logger.error({ message: "Failed to build JWK from key" + keyId }, JSON.stringify(map));
-	return null;
-};
-
-const getKeySpecMap = (
-	spec?: string,
-): { keySpec: string; algorithm: Algorithm } | undefined => {
-	if (spec == null) return undefined;
-	const conversions = [
-		{
-			keySpec: "ECC_NIST_P256",
-			algorithm: "ES256" as Algorithm,
-		},
-		{
-			keySpec: "RSA_2048",
-			algorithm: "RS256" as Algorithm,
-		},
-	];
-	return conversions.find(x => x.keySpec === spec);
-};
-const handlerClass = new JwksHandler();
+export const handlerClass = new JwksHandler();
 export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/src/JwksHandler.ts
+++ b/src/JwksHandler.ts
@@ -124,7 +124,7 @@ class JwksHandler implements LambdaInterface {
 			},
 			{
 				keySpec: "RSA_2048",
-				algorithm: "RS256" as Algorithm,
+				algorithm: "RSA-OAEP-256" as Algorithm,
 			},
 		];
 		return conversions.find(x => x.keySpec === spec);

--- a/src/jest.setup.ts
+++ b/src/jest.setup.ts
@@ -28,4 +28,7 @@ process.env.USE_MOCKED = "false";
 process.env.YOTI_LETTER_STATE_MACHINE_ARN = "MockSendYotiLetterStateMachine.Arn";
 process.env.OS_API_KEY_SSM_PATH = "Test/String";
 process.env.RESOURCES_TTL_SECS = "1209600";
+process.env.SIGNING_KEY_IDS = "f2f-cri-api-vc-signing-key";
+process.env.JWKS_BUCKET_NAME = "f2f-cri-api-jwks-dev";
+process.env.PUBLISHED_KEYS_BUCKET_NAME = "published-keys-bucket";
 

--- a/src/tests/unit/JwksHandler.test.ts
+++ b/src/tests/unit/JwksHandler.test.ts
@@ -173,7 +173,7 @@ describe("JwksHandler", () => {
 		it("returns the correct key spec map for RSA_2048 spec", () => {
 			expect(handlerClass.getKeySpecMap("RSA_2048")).toEqual({
 				keySpec: "RSA_2048",
-				algorithm: "RS256" as Algorithm,
+				algorithm: "RSA-OAEP-256" as Algorithm,
 			});
 		});
 	});

--- a/src/tests/unit/JwksHandler.test.ts
+++ b/src/tests/unit/JwksHandler.test.ts
@@ -1,5 +1,4 @@
 import { handlerClass, lambdaHandler, logger} from "../../JwksHandler";
-import { HttpCodesEnum } from "../../utils/HttpCodesEnum";
 import { Jwk, Algorithm } from "../../utils/IVeriCredential";
 import crypto from "crypto";
 
@@ -124,6 +123,7 @@ describe("JwksHandler", () => {
 
 		it("logs error if fetched key does not contain KeyId", async () => {
 			const keyId = "f2f-cri-api-vc-signing-key";
+			// pragma: allowlist nextline secret
 			const publicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES4sDJifz8h3GDznZZ6NC3QN5qlQn8Zf2mck4yBmlwqvXzZu7Wkwc4QuOxXhGHXamfkoG5d0UJVXJwwvFxiSzRQ==";
 			jest.spyOn(handlerClass.kmsClient, "getPublicKey").mockImplementationOnce(() => ({
 				KeySpec: "ECC_NIST_P256",

--- a/src/tests/unit/JwksHandler.test.ts
+++ b/src/tests/unit/JwksHandler.test.ts
@@ -1,0 +1,180 @@
+import { handlerClass, lambdaHandler, logger} from "../../JwksHandler";
+import { HttpCodesEnum } from "../../utils/HttpCodesEnum";
+import { Jwk, Algorithm } from "../../utils/IVeriCredential";
+import crypto from "crypto";
+
+jest.mock("@aws-lambda-powertools/logger", () => ({
+	Logger: jest.fn().mockImplementation(() => ({
+		info: jest.fn(),
+		error: jest.fn(),
+		warn: jest.fn(),
+	})),
+}));
+
+jest.mock("@aws-sdk/client-kms", () => ({
+	KMS: jest.fn().mockImplementation(() => ({
+		getPublicKey: jest.fn(),
+	})),
+}));
+
+jest.mock("crypto", () => ({
+	createPublicKey: jest.fn().mockImplementation(() => ({
+		export: jest.fn().mockImplementation(() => ({
+			key: "123456789",
+		})),
+	})),
+}));
+
+jest.mock("@aws-sdk/client-s3", () => ({
+	S3Client: jest.fn().mockImplementation(() => ({
+		send: jest.fn(),
+	})),
+	PutObjectCommand: jest.fn().mockImplementation((args) => args),
+	CopyObjectCommand: jest.fn().mockImplementation((args) => args),
+}));
+
+describe("JwksHandler", () => {
+	describe("#handler", () => {
+		beforeEach(() => {
+			jest.clearAllMocks(); 
+		});
+
+		it("uploads keys to s3", async () => {
+			const body = {
+				keys: [],
+			};
+    
+			await lambdaHandler();
+
+			expect(logger.info).toHaveBeenNthCalledWith(1, { message:"Building wellknown JWK endpoint with keys" + ["f2f-cri-api-vc-signing-key", "EncryptionKeyArn"] });
+			expect(handlerClass.s3Client.send).toHaveBeenCalledWith({
+				Bucket: "f2f-cri-api-jwks-dev",
+				Key: ".well-known/jwks.json",
+				Body: JSON.stringify(body),
+				ContentType: "application/json",
+			});
+		});
+
+		it("copies keys from jwks bucket to published keys bucket", async () => {
+			await lambdaHandler();
+
+			expect(logger.info).toHaveBeenCalledWith({ message: "Copying keys to published keys bucket" });
+			expect(handlerClass.s3Client.send).toHaveBeenCalledWith({
+				Bucket: "published-keys-bucket",
+				Key: "jwks.json",
+				CopySource: "f2f-cri-api-jwks-dev/.well-known/jwks.json",
+			});
+			expect(logger.info).toHaveBeenCalledWith({ message: "Keys copied to published keys bucket" });
+		});
+	});
+
+	describe("#getAsJwk", () => {
+		it("gets the kms key with the given KeyId and returns jwk with public key", async () => {
+			const keyId = "f2f-cri-api-vc-signing-key";
+			// pragma: allowlist nextline secret
+			const publicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES4sDJifz8h3GDznZZ6NC3QN5qlQn8Zf2mck4yBmlwqvXzZu7Wkwc4QuOxXhGHXamfkoG5d0UJVXJwwvFxiSzRQ==";
+			jest.spyOn(handlerClass.kmsClient, "getPublicKey").mockImplementationOnce(() => ({
+				KeySpec: "ECC_NIST_P256",
+				KeyId: keyId,
+				KeyUsage: "ENCRYPT_DECRYPT",
+				PublicKey: publicKey,
+			}));
+
+			const result = await handlerClass.getAsJwk(keyId);
+
+			expect(handlerClass.kmsClient.getPublicKey).toHaveBeenCalledWith({ KeyId: keyId });
+			expect(crypto.createPublicKey).toHaveBeenCalledWith({
+				key: publicKey as unknown as Buffer,
+				type: "spki",
+				format: "der",
+			});
+			expect(result).toEqual({
+				key: "123456789",
+				use: "enc",
+				kid: keyId.split("/").pop(),
+				alg: "ES256" as Algorithm,
+			} as unknown as Jwk);
+		});
+
+		it("logs error if no key is fetched", async () => {
+			const keyId = "f2f-cri-api-vc-signing-key";
+			jest.spyOn(handlerClass.kmsClient, "getPublicKey").mockImplementationOnce(() => null);
+
+			const result = await handlerClass.getAsJwk(keyId);
+
+			expect(logger.error).toHaveBeenCalledWith({ message: "Failed to build JWK from key" + keyId }, undefined);
+			expect(result).toBeNull();
+		});
+
+		it("logs error if fetched key does not contain KeySpec", async () => {
+			const keyId = "f2f-cri-api-vc-signing-key";
+			// pragma: allowlist nextline secret
+			const publicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES4sDJifz8h3GDznZZ6NC3QN5qlQn8Zf2mck4yBmlwqvXzZu7Wkwc4QuOxXhGHXamfkoG5d0UJVXJwwvFxiSzRQ==";
+			jest.spyOn(handlerClass.kmsClient, "getPublicKey").mockImplementationOnce(() => ({
+				KeyId: keyId,
+				KeyUsage: "ENCRYPT_DECRYPT",
+				PublicKey: publicKey,
+			}));
+
+			const result = await handlerClass.getAsJwk(keyId);
+
+			expect(logger.error).toHaveBeenCalledWith({ message: "Failed to build JWK from key" + keyId }, undefined);
+			expect(result).toBeNull();
+		});
+
+		it("logs error if fetched key does not contain KeyId", async () => {
+			const keyId = "f2f-cri-api-vc-signing-key";
+			const publicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES4sDJifz8h3GDznZZ6NC3QN5qlQn8Zf2mck4yBmlwqvXzZu7Wkwc4QuOxXhGHXamfkoG5d0UJVXJwwvFxiSzRQ==";
+			jest.spyOn(handlerClass.kmsClient, "getPublicKey").mockImplementationOnce(() => ({
+				KeySpec: "ECC_NIST_P256",
+				KeyUsage: "ENCRYPT_DECRYPT",
+				PublicKey: publicKey,
+			}));
+
+			const result = await handlerClass.getAsJwk(keyId);
+
+			expect(logger.error).toHaveBeenCalledWith({ message: "Failed to build JWK from key" + keyId }, JSON.stringify({
+				keySpec: "ECC_NIST_P256",
+				algorithm: "ES256" as Algorithm,
+			}));
+			expect(result).toBeNull();
+		});
+
+		it("logs error if fetched key does not contain PublicKey", async () => {
+			const keyId = "f2f-cri-api-vc-signing-key";
+			jest.spyOn(handlerClass.kmsClient, "getPublicKey").mockImplementationOnce(() => ({
+				KeySpec: "ECC_NIST_P256",
+				KeyUsage: "ENCRYPT_DECRYPT",
+				KeyId: keyId,
+			}));
+
+			const result = await handlerClass.getAsJwk(keyId);
+
+			expect(logger.error).toHaveBeenCalledWith({ message: "Failed to build JWK from key" + keyId }, JSON.stringify({
+				keySpec: "ECC_NIST_P256",
+				algorithm: "ES256" as Algorithm,
+			}));
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("#getKeySpecMap", () => {
+		it("returns undefined if spec is not given", () => {
+			expect(handlerClass.getKeySpecMap()).toBeUndefined();
+		});
+
+		it("returns the correct key spec map for ECC_NIST_P256 spec", () => {
+			expect(handlerClass.getKeySpecMap("ECC_NIST_P256")).toEqual({
+				keySpec: "ECC_NIST_P256",
+				algorithm: "ES256" as Algorithm,
+			});
+		});
+
+		it("returns the correct key spec map for RSA_2048 spec", () => {
+			expect(handlerClass.getKeySpecMap("RSA_2048")).toEqual({
+				keySpec: "RSA_2048",
+				algorithm: "RS256" as Algorithm,
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Proposed changes

### What changed

Implemented logic of copying keys from existing jwks bucket to new f2f published keys bucket in `JwksHandler` , and pointed well-known endpoint to new jwks/json folder. 
Added unit tests

### Why did it change

To facilitate key rotation initiative

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2335](https://govukverify.atlassian.net/browse/KIWI-2335)

### Lambda function executed successfully and `jwks.json` was updated 
<img width="799" alt="Screenshot 2025-07-08 at 16 03 51" src="https://github.com/user-attachments/assets/7494659a-7089-4b0f-8393-2539f7356336" />
<img width="873" alt="Screenshot 2025-07-08 at 16 04 56" src="https://github.com/user-attachments/assets/6a9a4d29-bcaf-452a-9628-5743f111ad7d" />


[KIWI-2335]: https://govukverify.atlassian.net/browse/KIWI-2335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ