### PR TITLE
[KIWI-2399B] - F2F | Platform | Verify new S3 bucket and connect to existing JWKS endpoint

### DIFF
--- a/deploy/f2f-spec.yaml
+++ b/deploy/f2f-spec.yaml
@@ -657,86 +657,6 @@ paths:
         credentials:
           Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/${JsonWebKeysBucket}/.well-known/jwks.json"
-        responses:
-          default:
-            statusCode: "200"
-        passthroughBehavior: "when_no_match"
-        contentHandling: "CONVERT_TO_TEXT"
-        type: "aws"
-  
-  /.well-known-test/jwks.json:
-    get:
-      operationId: getWellKnownTestJwksJson
-      summary: Return the contents of the published-keys bucket
-      tags:
-        - Backend - F2F CRI specific
-      responses:
-        "200":
-          description: >-
-            OK - key ring returned
-          headers:
-            Cache-Control:
-              schema:
-                type: "string"
-            Content-Type:
-              schema:
-                type: "string"
-            Strict-Transport-Security:
-              schema:
-                type: "string"
-            X-Content-Type-Options:
-              schema:
-                type: "string"
-            X-Frame-Options:
-              schema:
-                type: "string"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/JWKSFile"
-        "400":
-          description: 400 response
-          headers:
-            Cache-Control:
-              schema:
-                type: "string"
-            Content-Type:
-              schema:
-                type: "string"
-            Strict-Transport-Security:
-              schema:
-                type: "string"
-            X-Content-Type-Options:
-              schema:
-                type: "string"
-            X-Frame-Options:
-              schema:
-                type: "string"
-        "500":
-          description: Internal Server Error
-          headers:
-            Cache-Control:
-              schema:
-                type: "string"
-            Content-Type:
-              schema:
-                type: "string"
-            Strict-Transport-Security:
-              schema:
-                type: "string"
-            X-Content-Type-Options:
-              schema:
-                type: "string"
-            X-Frame-Options:
-              schema:
-                type: "string"
-      x-amazon-apigateway-request-validator: "both"
-      x-amazon-apigateway-integration:
-        httpMethod: "GET"
-        credentials:
-          Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
-        uri:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-f2f-published-keys-${Environment}/jwks.json"
         responses:
           default:
@@ -744,7 +664,7 @@ paths:
         passthroughBehavior: "when_no_match"
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws"
-
+  
   /userinfo:
     post:
       operationId: postUserInfo


### PR DESCRIPTION
## Proposed changes

### What changed

Followup PR(KIWI-2399) 

- Removed test endpoint  after confirming contents of bucket in production environment
- Updated S3 intagration to use new "published-keys" bucket 

### Why did it change
To ensure the /.well-known e/p points to the correct bucket for key rotation, following successful update and execution of the JWKS lambda (which publishes existing keys to the new "published-keys" bucket)

### Issue tracking

- [KIWI-2399](https://govukverify.atlassian.net/browse/KIWI-2399)

### Evidence
<img width="901" height="489" alt="Screenshot 2025-08-08 at 11 48 22" src="https://github.com/user-attachments/assets/34def638-2a14-4e68-84e6-ff5fd413c61e" />


