### PR TITLE
[KIWI-2477] - F2F | Add FMS tags for custom WAF policy migration in lower environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -692,8 +692,8 @@ Resources:
         Service: backend
         Name: F2FRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: !If [IsNotProdLikeEnvironment, false, !Ref "AWS::NoValue"]
-        CustomPolicy: !If [IsNotProdLikeEnvironment, true, !Ref "AWS::NoValue"]
+        FMSRegionalPolicy: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "false"]
+        CustomPolicy: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "true"]
 
   F2FAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -747,9 +747,9 @@ Resources:
       SecurityPolicy: TLS_1_2
       Tags:
         - Key: FMSRegionalPolicy
-          Value: !If [IsNotProdLikeEnvironment, false, !Ref "AWS::NoValue"]
+          Value: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "false"]
         - Key: CustomPolicy
-          Value: !If [IsNotProdLikeEnvironment, true, !Ref "AWS::NoValue"]
+          Value: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "true"]
 
   F2FApiBasePath:
     Type: AWS::ApiGateway::BasePathMapping

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -692,8 +692,8 @@ Resources:
         Service: backend
         Name: F2FRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [IsNotProdLikeEnvironment, false, !Ref "AWS::NoValue"]
+        CustomPolicy: !If [IsNotProdLikeEnvironment, true, !Ref "AWS::NoValue"]
 
   F2FAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -745,6 +745,11 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
       SecurityPolicy: TLS_1_2
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: !If [IsNotProdLikeEnvironment, false, !Ref "AWS::NoValue"]
+        - Key: CustomPolicy
+          Value: !If [IsNotProdLikeEnvironment, true, !Ref "AWS::NoValue"]
 
   F2FApiBasePath:
     Type: AWS::ApiGateway::BasePathMapping


### PR DESCRIPTION
## Proposed changes

### What changed

Added regional(API Gateway/Load Balancer Tags to template file

### Why did it change

As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope.

### Issue tracking

- [KIWI-2477](https://govukverify.atlassian.net/browse/KIWI-2477)
<img width="1308" height="605" alt="Screenshot 2025-10-01 at 15 39 38" src="https://github.com/user-attachments/assets/4b1a4a0d-8e25-4e29-835a-88da2822f9a9" />
<img width="1322" height="602" alt="Screenshot 2025-10-01 at 15 50 53" src="https://github.com/user-attachments/assets/a3af9715-37dd-4b3b-ad41-6f90ab0bdef1" />



[KIWI-2477]: https://govukverify.atlassian.net/browse/KIWI-2477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ