### PR TITLE
[KIWI-2477B] - F2F | Add FMS tags for custom WAF policy migration in lower environments 

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -692,8 +692,8 @@ Resources:
         Service: backend
         Name: F2FRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: !If [IsNotProdLikeEnvironment, false, !Ref "AWS::NoValue"]
-        CustomPolicy: !If [IsNotProdLikeEnvironment, true, !Ref "AWS::NoValue"]
+        FMSRegionalPolicy: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "false"]
+        CustomPolicy: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "true"]
 
   F2FAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -747,9 +747,9 @@ Resources:
       SecurityPolicy: TLS_1_2
       Tags:
         - Key: FMSRegionalPolicy
-          Value: !If [IsNotProdLikeEnvironment, false, !Ref "AWS::NoValue"]
+          Value: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "false"]
         - Key: CustomPolicy
-          Value: !If [IsNotProdLikeEnvironment, true, !Ref "AWS::NoValue"]
+          Value: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "true"]
 
   F2FApiBasePath:
     Type: AWS::ApiGateway::BasePathMapping

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -327,6 +327,10 @@ Conditions:
     - !Not [ !Equals [ !Ref TrafficTestRoleArn, none ]]
 
   UseCanaryDeploymentAlarms: !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
+  IsDevOrBuildOrStaging: !Or
+    - !Equals [ !Ref Environment, dev ]
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
 
 Globals:
   Function:
@@ -692,8 +696,8 @@ Resources:
         Service: backend
         Name: F2FRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "false"]
-        CustomPolicy: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "true"]
+        FMSRegionalPolicy: !If [ IsDevOrBuildOrStaging, "false", "none" ]
+        CustomPolicy: !If [ IsDevOrBuildOrStaging, "true", "none" ]
 
   F2FAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -745,11 +749,6 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
       SecurityPolicy: TLS_1_2
-      Tags:
-        - Key: FMSRegionalPolicy
-          Value: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "false"]
-        - Key: CustomPolicy
-          Value: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "true"]
 
   F2FApiBasePath:
     Type: AWS::ApiGateway::BasePathMapping

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -692,8 +692,8 @@ Resources:
         Service: backend
         Name: F2FRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [IsNotProdLikeEnvironment, false, !Ref "AWS::NoValue"]
+        CustomPolicy: !If [IsNotProdLikeEnvironment, true, !Ref "AWS::NoValue"]
 
   F2FAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -745,6 +745,11 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
       SecurityPolicy: TLS_1_2
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: !If [IsNotProdLikeEnvironment, false, !Ref "AWS::NoValue"]
+        - Key: CustomPolicy
+          Value: !If [IsNotProdLikeEnvironment, true, !Ref "AWS::NoValue"]
 
   F2FApiBasePath:
     Type: AWS::ApiGateway::BasePathMapping


### PR DESCRIPTION
## Proposed changes

### What changed

Added regional(API Gateway/Load Balancer Tags to template file

### Why did it change

As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope.

### Issue tracking

- [KIWI-2477](https://govukverify.atlassian.net/browse/KIWI-2477)

<img width="1309" height="595" alt="Screenshot 2025-10-02 at 17 09 08" src="https://github.com/user-attachments/assets/7dc30cce-ec25-4f24-94f1-09236808492d" />



[KIWI-2477]: https://govukverify.atlassian.net/browse/KIWI-2477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ